### PR TITLE
Move to serving db in connection pool, and refactor tests around testify/suite

### DIFF
--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -3,18 +3,18 @@ package auth
 import (
 	"errors"
 
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
-	"gorm.io/gorm"
 )
 
 // FetchAuthenticatedUser retrieves the user to satisfy AuthenticatedUserResolver
-func FetchAuthenticatedUser(db *gorm.DB, header string) (interface{}, error) {
+func FetchAuthenticatedUser(header string) (interface{}, error) {
 	token, err := RetrieveAccessToken(header)
 	if err != nil {
 		return nil, err
 	}
 	authToken := &models.AuthToken{}
-	if err := db.Preload("User").Where("access_token = ?", token).Last(&authToken).Error; err != nil {
+	if err := db.Manager.Preload("User").Where("access_token = ?", token).Last(&authToken).Error; err != nil {
 		return nil, errors.New("token invalid/expired")
 	}
 	return authToken.User, nil

--- a/internal/pkg/auth/create_user.go
+++ b/internal/pkg/auth/create_user.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/mailer"
 	uuid "github.com/satori/go.uuid"
@@ -12,7 +13,7 @@ import (
 )
 
 // CreateUser creates a user account with an email and password
-func CreateUser(db *gorm.DB, email string, password string, clientID uuid.UUID) (*models.User, error) {
+func CreateUser(email string, password string, clientID uuid.UUID) (*models.User, error) {
 	passhash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, err
@@ -20,7 +21,7 @@ func CreateUser(db *gorm.DB, email string, password string, clientID uuid.UUID) 
 
 	// Handle dupe email
 	dupeUser := &models.User{}
-	if err := db.Where("email = ?", email).First(&dupeUser).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+	if err := db.Manager.Where("email = ?", email).First(&dupeUser).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, errors.New("An account with this email address already exists")
 	}
 
@@ -30,7 +31,7 @@ func CreateUser(db *gorm.DB, email string, password string, clientID uuid.UUID) 
 		LastSeenAt: time.Now(),
 		Tokens:     []models.AuthToken{{ClientID: clientID}},
 	}
-	if err := db.Create(&user).Error; err != nil {
+	if err := db.Manager.Create(&user).Error; err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/db/main.go
+++ b/internal/pkg/db/main.go
@@ -13,10 +13,12 @@ import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/migration"
 )
 
-// ORM struct holds the gorm pointer to DB
-type ORM struct {
-	DB *gorm.DB
+// DatabaseManager variable holds the gorm pointer to DB
+type DatabaseManager struct {
+	db *gorm.DB
 }
+
+var Manager *gorm.DB
 
 // FetchConnection establishes a database connection
 func FetchConnection() *gorm.DB {
@@ -28,17 +30,13 @@ func FetchConnection() *gorm.DB {
 	return db
 }
 
-// Factory fetches a database connection, and runs some config (i.e. auto migrations)
-func Factory() *ORM {
-	db := FetchConnection()
-	orm := &ORM{DB: db}
+func Factory() {
+	Manager = FetchConnection()
 
 	// Automigrate on init
 	log.Println("[db] Performing migrations...")
-	if err := migration.AutoMigrateService(orm.DB); err != nil {
+	if err := migration.AutoMigrateService(Manager); err != nil {
 		log.Fatal("[db] Couldn't perform migrations! ", err)
 	}
 	log.Println("[db] Database connection initialized")
-
-	return orm
 }

--- a/internal/pkg/db/main_test.go
+++ b/internal/pkg/db/main_test.go
@@ -17,7 +17,3 @@ func TestFetchConnection(t *testing.T) {
 		t.Fatalf("main_test.go: TestDBConnection error %v", err)
 	}
 }
-
-// func TestFactory(t *testing.T) {
-// 	db := TestFetchConnection(t)
-// }

--- a/internal/pkg/gql/main.go
+++ b/internal/pkg/gql/main.go
@@ -4,7 +4,6 @@ import (
 	"github.com/graphql-go/graphql"
 
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/gql/resolvers"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/gql/subscriptions"
@@ -246,15 +245,13 @@ func init() {
 						},
 					},
 					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						db := db.FetchConnection()
-
 						header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-						user, err := auth.FetchAuthenticatedUser(db, header.(string))
+						user, err := auth.FetchAuthenticatedUser(header.(string))
 						if err != nil {
 							return nil, err
 						}
 
-						item, err := trips.AddItem(db, user.(models.User).ID, p.Args)
+						item, err := trips.AddItem(user.(models.User).ID, p.Args)
 						if err != nil {
 							return nil, err
 						}

--- a/internal/pkg/gql/resolvers/create_store.go
+++ b/internal/pkg/gql/resolvers/create_store.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
 	"github.com/graphql-go/graphql"
@@ -10,16 +9,14 @@ import (
 
 // CreateStoreResolver creates a new store for the currently authenticated user
 func CreateStoreResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(db, header.(string))
+	user, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
 	userID := user.(models.User).ID
-	store, err := stores.CreateStore(db, userID, p.Args["name"].(string))
+	store, err := stores.CreateStore(userID, p.Args["name"].(string))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/decline_store_invite.go
+++ b/internal/pkg/gql/resolvers/decline_store_invite.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
 	"github.com/graphql-go/graphql"
@@ -12,16 +11,14 @@ import (
 // stores.RemoveUserFromStore function which handles removing the StoreUser record
 // and emailing the store creator about the invite being declined
 func DeclineStoreInviteResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(db, header.(string))
+	user, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
 	storeID := p.Args["storeId"]
-	storeUser, err := stores.RemoveUserFromStore(db, user.(models.User), storeID)
+	storeUser, err := stores.RemoveUserFromStore(user.(models.User), storeID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/delete_item.go
+++ b/internal/pkg/gql/resolvers/delete_item.go
@@ -2,23 +2,20 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/trips"
 	"github.com/graphql-go/graphql"
 )
 
 // DeleteItemResolver deletes an item by itemId param
 func DeleteItemResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	_, err := auth.FetchAuthenticatedUser(db, header.(string))
+	_, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
 	itemID := p.Args["itemId"]
-	item, err := trips.DeleteItem(db, itemID)
+	item, err := trips.DeleteItem(itemID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/delete_store.go
+++ b/internal/pkg/gql/resolvers/delete_store.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
 	"github.com/graphql-go/graphql"
@@ -11,15 +10,13 @@ import (
 // DeleteStoreResolver resolves the deleteStore mutation by deleting a store
 // and its associated store users and items
 func DeleteStoreResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(db, header.(string))
+	user, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
-	store, err := stores.DeleteStore(db, p.Args["storeId"], user.(models.User).ID)
+	store, err := stores.DeleteStore(p.Args["storeId"], user.(models.User).ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/grocery_trip.go
+++ b/internal/pkg/gql/resolvers/grocery_trip.go
@@ -2,23 +2,20 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/trips"
 	"github.com/graphql-go/graphql"
 )
 
 // GroceryTripResolver retrieves a grocery trip by ID
 func GroceryTripResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	_, err := auth.FetchAuthenticatedUser(db, header.(string))
+	_, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
 	tripID := p.Args["id"]
-	trip, err := trips.RetrieveTrip(db, tripID)
+	trip, err := trips.RetrieveTrip(tripID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/invite_to_store.go
+++ b/internal/pkg/gql/resolvers/invite_to_store.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
 	"github.com/graphql-go/graphql"
@@ -14,10 +13,8 @@ import (
 // InviteToStoreResolver resolves the inviteToStore mutation by creating a pending
 // store_users record for the given storeId and email
 func InviteToStoreResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(db, header.(string))
+	user, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +26,7 @@ func InviteToStoreResolver(p graphql.ResolveParams) (interface{}, error) {
 	if userEmail == invitedUserEmail {
 		return models.StoreUser{}, errors.New("cannot invite yourself to a store")
 	}
-	storeUser, err := stores.InviteToStoreByEmail(db, storeID, invitedUserEmail)
+	storeUser, err := stores.InviteToStoreByEmail(storeID, invitedUserEmail)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/invited_stores.go
+++ b/internal/pkg/gql/resolvers/invited_stores.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
 	"github.com/graphql-go/graphql"
@@ -11,15 +10,13 @@ import (
 // InvitedStoresResolver resolves the invitedStores query by retrieving stores
 // that the current user has been invited to
 func InvitedStoresResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(db, header.(string))
+	user, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
-	invites, err := stores.RetrieveInvitedUserStores(db, user.(models.User))
+	invites, err := stores.RetrieveInvitedUserStores(user.(models.User))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/join_store.go
+++ b/internal/pkg/gql/resolvers/join_store.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
 
@@ -12,17 +11,15 @@ import (
 // JoinStoreResolver adds the current user to a store properly by removing
 // the email and replacing it with the user ID
 func JoinStoreResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(db, header.(string))
+	user, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
 	// Verify that the store with the ID provided exists
 	storeID := p.Args["storeId"]
-	storeUser, err := stores.AddUserToStore(db, user.(models.User), storeID)
+	storeUser, err := stores.AddUserToStore(user.(models.User), storeID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/leave_store.go
+++ b/internal/pkg/gql/resolvers/leave_store.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
 	"github.com/graphql-go/graphql"
@@ -10,17 +9,15 @@ import (
 
 // LeaveStoreResolver resolves the leaveStore resolver by removing the current user from the store
 func LeaveStoreResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(db, header.(string))
+	user, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
 	// Verify that the store with the ID provided exists
 	storeID := p.Args["storeId"]
-	storeUser, err := stores.RemoveUserFromStore(db, user.(models.User), storeID)
+	storeUser, err := stores.RemoveUserFromStore(user.(models.User), storeID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/reorder_item.go
+++ b/internal/pkg/gql/resolvers/reorder_item.go
@@ -2,24 +2,21 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/trips"
 	"github.com/graphql-go/graphql"
 )
 
 // ReorderItemResolver updates the position of an item with the provided params
 func ReorderItemResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	_, err := auth.FetchAuthenticatedUser(db, header.(string))
+	_, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
 	itemID := p.Args["itemId"]
 	position := p.Args["position"].(int)
-	trip, err := trips.ReorderItem(db, itemID, position)
+	trip, err := trips.ReorderItem(itemID, position)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/signup.go
+++ b/internal/pkg/gql/resolvers/signup.go
@@ -10,8 +10,6 @@ import (
 
 // SignupResolver creates a new user account and assigns it a
 func SignupResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	// Retrieve API client for the key/secret provided
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
 	creds, err := auth.RetrieveClientCredentials(header.(string))
@@ -19,14 +17,14 @@ func SignupResolver(p graphql.ResolveParams) (interface{}, error) {
 		return nil, err
 	}
 	apiClient := &models.ApiClient{}
-	if err := db.Where("key = ? AND secret = ?", creds[0], creds[1]).First(&apiClient).Error; err != nil {
+	if err := db.Manager.Where("key = ? AND secret = ?", creds[0], creds[1]).First(&apiClient).Error; err != nil {
 		return nil, err
 	}
 
 	// Create a new user account with the args provided
 	email := p.Args["email"].(string)
 	password := p.Args["password"].(string)
-	user, err := auth.CreateUser(db, email, password, apiClient.ID)
+	user, err := auth.CreateUser(email, password, apiClient.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/store.go
+++ b/internal/pkg/gql/resolvers/store.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
 	"github.com/graphql-go/graphql"
@@ -10,15 +9,13 @@ import (
 
 // StoreResolver resolves the store GraphQL query by retrieving a store by ID param
 func StoreResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(db, header.(string))
+	user, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
-	store, err := stores.RetrieveStoreForUser(db, p.Args["id"], user.(models.User).ID)
+	store, err := stores.RetrieveStoreForUser(p.Args["id"], user.(models.User).ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/stores.go
+++ b/internal/pkg/gql/resolvers/stores.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
 	"github.com/graphql-go/graphql"
@@ -10,15 +9,13 @@ import (
 
 // StoresResolver returns Store records for the current user
 func StoresResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(db, header.(string))
+	user, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
-	userStores, err := stores.RetrieveUserStores(db, user.(models.User))
+	userStores, err := stores.RetrieveUserStores(user.(models.User))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/update_item.go
+++ b/internal/pkg/gql/resolvers/update_item.go
@@ -2,22 +2,19 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/trips"
 	"github.com/graphql-go/graphql"
 )
 
 // UpdateItemResolver updates the properties of an item with the provided params
 func UpdateItemResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	_, err := auth.FetchAuthenticatedUser(db, header.(string))
+	_, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
-	item, err := trips.UpdateItem(db, p.Args)
+	item, err := trips.UpdateItem(p.Args)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/update_store.go
+++ b/internal/pkg/gql/resolvers/update_store.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
 	"github.com/graphql-go/graphql"
@@ -10,15 +9,13 @@ import (
 
 // UpdateStoreResolver resolves the updateStore mutation by updating the properties of a store
 func UpdateStoreResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(db, header.(string))
+	user, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
-	store, err := stores.UpdateStoreForUser(db, user.(models.User).ID, p.Args)
+	store, err := stores.UpdateStoreForUser(user.(models.User).ID, p.Args)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/update_trip.go
+++ b/internal/pkg/gql/resolvers/update_trip.go
@@ -2,22 +2,19 @@ package resolvers
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/trips"
 	"github.com/graphql-go/graphql"
 )
 
 // UpdateTripResolver updates the properties of a trip with the provided params
 func UpdateTripResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	_, err := auth.FetchAuthenticatedUser(db, header.(string))
+	_, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
 
-	item, err := trips.UpdateTrip(db, p.Args)
+	item, err := trips.UpdateTrip(p.Args)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/user.go
+++ b/internal/pkg/gql/resolvers/user.go
@@ -11,10 +11,9 @@ import (
 // AuthenticatedUserResolver resolves me GraphQL query by returning the
 // authenticated user, or an error if no authenticated user exists
 func AuthenticatedUserResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
 
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(db, header.(string))
+	user, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
@@ -24,10 +23,8 @@ func AuthenticatedUserResolver(p graphql.ResolveParams) (interface{}, error) {
 // BasicUserResolver resolves the creator field in the StoreType by retrieving
 // basic information about a user (email, first name, last name)
 func BasicUserResolver(p graphql.ResolveParams) (interface{}, error) {
-	db := db.FetchConnection()
-
 	user := &models.User{}
-	if err := db.Where("id = ?", p.Source.(models.Store).UserID).Find(&user).Error; err != nil {
+	if err := db.Manager.Where("id = ?", p.Source.(models.Store).UserID).Find(&user).Error; err != nil {
 		return nil, err
 	}
 	return user, nil

--- a/internal/pkg/gql/subscriptions/deleted_item.go
+++ b/internal/pkg/gql/subscriptions/deleted_item.go
@@ -15,14 +15,12 @@ import (
 func DeletedItem(p graphql.ResolveParams) (interface{}, error) {
 	fmt.Println("Processing subscription DeletedItem...")
 
-	db := db.FetchConnection()
-
 	rootValue := p.Info.RootValue.(map[string]interface{})
 	payload := rootValue["deleteItem"].(map[string]interface{})
 
 	tripID := p.Args["tripId"]
 	item := &models.Item{}
-	query := db.
+	query := db.Manager.
 		Where("id = ? AND grocery_trip_id = ?", payload["id"], tripID).
 		First(&item).
 		Error

--- a/internal/pkg/gql/subscriptions/new_item.go
+++ b/internal/pkg/gql/subscriptions/new_item.go
@@ -12,13 +12,11 @@ import (
 func NewItem(p graphql.ResolveParams) (interface{}, error) {
 	fmt.Println("Processing subscription NewItem...")
 
-	db := db.FetchConnection()
-
 	rootValue := p.Info.RootValue.(map[string]interface{})
 	payload := rootValue["addItemToTrip"].(map[string]interface{})
 	item := &models.Item{}
 	tripID := p.Args["tripId"]
-	if err := db.Where("id = ? AND grocery_trip_id = ?", payload["id"], tripID).First(&item).Error; err != nil {
+	if err := db.Manager.Where("id = ? AND grocery_trip_id = ?", payload["id"], tripID).First(&item).Error; err != nil {
 		return nil, err
 	}
 	return item, nil

--- a/internal/pkg/gql/subscriptions/updated_item.go
+++ b/internal/pkg/gql/subscriptions/updated_item.go
@@ -15,14 +15,12 @@ import (
 func UpdatedItem(p graphql.ResolveParams) (interface{}, error) {
 	fmt.Println("Processing subscription UpdatedItem...")
 
-	db := db.FetchConnection()
-
 	rootValue := p.Info.RootValue.(map[string]interface{})
 	payload := rootValue["updateItem"].(map[string]interface{})
 
 	tripID := p.Args["tripId"]
 	item := &models.Item{}
-	if err := db.Where("id = ? AND grocery_trip_id = ?", payload["id"], tripID).First(&item).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+	if err := db.Manager.Where("id = ? AND grocery_trip_id = ?", payload["id"], tripID).First(&item).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err
 	}
 

--- a/internal/pkg/gql/types/grocery_trip.go
+++ b/internal/pkg/gql/types/grocery_trip.go
@@ -31,11 +31,9 @@ var GroceryTripType = graphql.NewObject(
 			"categories": &graphql.Field{
 				Type: graphql.NewList(GroceryTripCategoryType),
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					db := db.FetchConnection()
-
 					tripID := p.Source.(models.GroceryTrip).ID
 					categories := []models.GroceryTripCategory{}
-					query := db.
+					query := db.Manager.
 						Joins("INNER JOIN store_categories ON store_categories.id = grocery_trip_categories.store_category_id").
 						Where("grocery_trip_categories.grocery_trip_id = ?", tripID).
 						Order("grocery_trip_categories.created_at DESC").

--- a/internal/pkg/gql/types/grocery_trip_category.go
+++ b/internal/pkg/gql/types/grocery_trip_category.go
@@ -17,11 +17,9 @@ var GroceryTripCategoryType = graphql.NewObject(
 			"storeCategory": &graphql.Field{
 				Type: StoreCategoryType,
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					db := db.FetchConnection()
-
 					storeCategoryID := p.Source.(models.GroceryTripCategory).StoreCategoryID
 					storeCategory := models.StoreCategory{}
-					if err := db.Select("id, name").Where("id = ?", storeCategoryID).First(&storeCategory).Error; err != nil {
+					if err := db.Manager.Select("id, name").Where("id = ?", storeCategoryID).First(&storeCategory).Error; err != nil {
 						return nil, err
 					}
 					return storeCategory, nil
@@ -35,11 +33,9 @@ var GroceryTripCategoryType = graphql.NewObject(
 					},
 				},
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					db := db.FetchConnection()
-
 					tripID := p.Source.(models.GroceryTripCategory).GroceryTripID
 					categoryID := p.Source.(models.GroceryTripCategory).ID
-					items, err := trips.RetrieveItemsInCategory(db, tripID, categoryID)
+					items, err := trips.RetrieveItemsInCategory(tripID, categoryID)
 					if err != nil {
 						return nil, err
 					}

--- a/internal/pkg/gql/types/item.go
+++ b/internal/pkg/gql/types/item.go
@@ -27,15 +27,13 @@ var ItemType = graphql.NewObject(
 			"categoryName": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					db := db.FetchConnection()
-
 					groceryTripCategoryID := p.Source.(models.Item).CategoryID
 					groceryTripCategory := &models.GroceryTripCategory{}
-					if err := db.Select("store_category_id").Where("id = ?", groceryTripCategoryID).First(&groceryTripCategory).Error; err != nil {
+					if err := db.Manager.Select("store_category_id").Where("id = ?", groceryTripCategoryID).First(&groceryTripCategory).Error; err != nil {
 						return nil, err
 					}
 					storeCategory := &models.StoreCategory{}
-					if err := db.Select("name").Where("id = ?", groceryTripCategory.StoreCategoryID).First(&storeCategory).Error; err != nil {
+					if err := db.Manager.Select("name").Where("id = ?", groceryTripCategory.StoreCategoryID).First(&storeCategory).Error; err != nil {
 						return nil, err
 					}
 
@@ -60,11 +58,9 @@ var ItemType = graphql.NewObject(
 			"user": &graphql.Field{
 				Type: UserType,
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					db := db.FetchConnection()
-
 					userID := p.Source.(models.Item).UserID
 					user := &models.User{}
-					if err := db.Where("id = ?", userID).First(&user).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+					if err := db.Manager.Where("id = ?", userID).First(&user).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 						return nil, err
 					}
 					return user, nil

--- a/internal/pkg/gql/types/store.go
+++ b/internal/pkg/gql/types/store.go
@@ -2,7 +2,6 @@ package gql
 
 import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/gql/resolvers"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
@@ -31,16 +30,14 @@ var StoreType = graphql.NewObject(
 			"trip": &graphql.Field{
 				Type: GroceryTripType,
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					db := db.FetchConnection()
-
 					header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-					user, err := auth.FetchAuthenticatedUser(db, header.(string))
+					user, err := auth.FetchAuthenticatedUser(header.(string))
 					if err != nil {
 						return nil, err
 					}
 
 					storeID := p.Source.(models.Store).ID
-					trip, err := trips.RetrieveCurrentStoreTrip(db, storeID, user.(models.User))
+					trip, err := trips.RetrieveCurrentStoreTrip(storeID, user.(models.User))
 					if err != nil {
 						return nil, err
 					}
@@ -50,10 +47,8 @@ var StoreType = graphql.NewObject(
 			"users": &graphql.Field{
 				Type: graphql.NewList(StoreUserType),
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					db := db.FetchConnection()
-
 					storeID := p.Source.(models.Store).ID
-					storeUsers, err := stores.RetrieveStoreUsers(db, storeID)
+					storeUsers, err := stores.RetrieveStoreUsers(storeID)
 					if err != nil {
 						return nil, err
 					}

--- a/internal/pkg/gql/types/store_invite.go
+++ b/internal/pkg/gql/types/store_invite.go
@@ -1,7 +1,6 @@
 package gql
 
 import (
-	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
 	"github.com/graphql-go/graphql"
@@ -28,12 +27,10 @@ var StoreInviteType = graphql.NewObject(
 				Type:        UserType,
 				Description: "Returns the user who sent the invite",
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					db := db.FetchConnection()
-
-					// Return the store user who created this store, as this will always
-					// be the user who sent the invite
+					// Return the store user who created this store,
+					// as this will always be the user who sent the invite
 					storeID := p.Source.(models.Store).ID
-					user, err := stores.RetrieveStoreCreator(db, storeID)
+					user, err := stores.RetrieveStoreCreator(storeID)
 					if err != nil {
 						return nil, err
 					}

--- a/internal/pkg/gql/types/store_user.go
+++ b/internal/pkg/gql/types/store_user.go
@@ -41,11 +41,9 @@ var StoreUserType = graphql.NewObject(
 			"user": &graphql.Field{
 				Type: UserType,
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					db := db.FetchConnection()
-
 					userID := p.Source.(models.StoreUser).UserID
 					user := &models.User{}
-					if err := db.Where("id = ?", userID).First(&user).Error; err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
+					if err := db.Manager.Where("id = ?", userID).First(&user).Error; err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
 						return nil, err
 					}
 					return user, nil

--- a/internal/pkg/gql/types/user.go
+++ b/internal/pkg/gql/types/user.go
@@ -34,11 +34,9 @@ var UserType = graphql.NewObject(
 			"token": &graphql.Field{
 				Type: AuthTokenType,
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					db := db.FetchConnection()
-
 					userID := p.Source.(*models.User).ID
 					authToken := &models.AuthToken{}
-					if err := db.Where("user_id = ?", userID).Last(&authToken).Error; err != nil {
+					if err := db.Manager.Where("user_id = ?", userID).Last(&authToken).Error; err != nil {
 						return nil, errors.New("token not found for user")
 					}
 					return authToken, nil

--- a/internal/pkg/stores/create.go
+++ b/internal/pkg/stores/create.go
@@ -3,19 +3,19 @@ package stores
 import (
 	"errors"
 
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	uuid "github.com/satori/go.uuid"
-	"gorm.io/gorm"
 )
 
 // CreateStore creates a store for a user if it does not already exist by name
-func CreateStore(db *gorm.DB, userID uuid.UUID, name string) (models.Store, error) {
-	dupeStore, _ := RetrieveStoreForUserByName(db, name, userID)
+func CreateStore(userID uuid.UUID, name string) (models.Store, error) {
+	dupeStore, _ := RetrieveStoreForUserByName(name, userID)
 	if dupeStore.Name != "" {
 		return models.Store{}, errors.New("You already added a store with this name")
 	}
 	store := models.Store{UserID: userID, Name: name}
-	if err := db.Debug().Create(&store).Error; err != nil {
+	if err := db.Manager.Create(&store).Error; err != nil {
 		return models.Store{}, err
 	}
 	return store, nil

--- a/internal/pkg/stores/stores_test.go
+++ b/internal/pkg/stores/stores_test.go
@@ -1,0 +1,48 @@
+package stores
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type AnyTime struct{}
+
+// Match satisfies sqlmock.Argument interface
+func (a AnyTime) Match(v driver.Value) bool {
+	_, ok := v.(time.Time)
+	return ok
+}
+
+type Suite struct {
+	suite.Suite
+
+	DB   *gorm.DB
+	mock sqlmock.Sqlmock
+}
+
+func (s *Suite) SetupSuite() {
+	var (
+		dbMock *sql.DB
+		err    error
+	)
+
+	dbMock, s.mock, err = sqlmock.New()
+	require.NoError(s.T(), err)
+	s.DB, err = gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
+	require.NoError(s.T(), err)
+
+	db.Manager = s.DB
+}
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, new(Suite))
+}

--- a/internal/pkg/stores/update.go
+++ b/internal/pkg/stores/update.go
@@ -1,16 +1,16 @@
 package stores
 
 import (
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/mailer"
 	uuid "github.com/satori/go.uuid"
-	"gorm.io/gorm"
 )
 
 // UpdateStoreForUser updates a store for the given userID with the provided args
-func UpdateStoreForUser(db *gorm.DB, userID uuid.UUID, args map[string]interface{}) (interface{}, error) {
+func UpdateStoreForUser(userID uuid.UUID, args map[string]interface{}) (interface{}, error) {
 	store := &models.Store{}
-	if err := db.Where("id = ? AND user_id = ?", args["storeId"], userID).First(&store).Error; err != nil {
+	if err := db.Manager.Where("id = ? AND user_id = ?", args["storeId"], userID).First(&store).Error; err != nil {
 		return nil, err
 	}
 
@@ -18,13 +18,13 @@ func UpdateStoreForUser(db *gorm.DB, userID uuid.UUID, args map[string]interface
 	if args["name"] != nil {
 		store.Name = args["name"].(string)
 	}
-	if err := db.Save(&store).Error; err != nil {
+	if err := db.Manager.Save(&store).Error; err != nil {
 		return nil, err
 	}
 
 	// Finally, send an email to the users of this store about this update (excluding the creator)
 	if oldName != args["name"] {
-		rows, err := db.Raw("SELECT u.email FROM store_users AS su INNER JOIN users AS u ON su.user_id = u.id WHERE su.store_id = ? AND su.creator = ? ORDER BY su.created_at DESC", store.ID, false).Rows()
+		rows, err := db.Manager.Raw("SELECT u.email FROM store_users AS su INNER JOIN users AS u ON su.user_id = u.id WHERE su.store_id = ? AND su.creator = ? ORDER BY su.created_at DESC", store.ID, false).Rows()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/stores/update_test.go
+++ b/internal/pkg/stores/update_test.go
@@ -1,23 +1,14 @@
 package stores
 
 import (
-	"testing"
-
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
 )
 
-func TestUpdateStoreForUser_NoUpdates(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestUpdateStoreForUser_NoUpdates() {
 	storeID := uuid.NewV4()
 	userID := uuid.NewV4()
 	storeRows := sqlmock.
@@ -28,33 +19,27 @@ func TestUpdateStoreForUser_NoUpdates(t *testing.T) {
 		}).
 		AddRow(storeID, userID, "My Original Store")
 
-	mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
 		WithArgs(storeID, userID).
 		WillReturnRows(storeRows)
 
-	mock.ExpectBegin()
-	mock.ExpectExec("^UPDATE \"stores\" SET (.+)$").
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec("^UPDATE \"stores\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
+	s.mock.ExpectCommit()
 
-	mock.ExpectQuery("^SELECT u.email FROM store_users AS su*").
+	s.mock.ExpectQuery("^SELECT u.email FROM store_users AS su*").
 		WithArgs(storeID, false).
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
 	args := map[string]interface{}{"storeId": storeID}
-	store, err := UpdateStoreForUser(db, userID, args)
-	require.NoError(t, err)
-	// Assert no changes
-	assert.Equal(t, store.(*models.Store).ID, storeID)
-	assert.Equal(t, store.(*models.Store).Name, "My Original Store")
+	store, err := UpdateStoreForUser(userID, args)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), store.(*models.Store).ID, storeID)
+	assert.Equal(s.T(), store.(*models.Store).Name, "My Original Store")
 }
 
-func TestUpdateStoreForUser_UpdateSingleColumn(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestUpdateStoreForUser_UpdateSingleColumn() {
 	storeID := uuid.NewV4()
 	userID := uuid.NewV4()
 	storeRows := sqlmock.
@@ -64,24 +49,24 @@ func TestUpdateStoreForUser_UpdateSingleColumn(t *testing.T) {
 		}).
 		AddRow(storeID, userID)
 
-	mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
 		WithArgs(storeID, userID).
 		WillReturnRows(storeRows)
 
-	mock.ExpectBegin()
-	mock.ExpectExec("^UPDATE \"stores\" SET (.+)$").
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec("^UPDATE \"stores\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
+	s.mock.ExpectCommit()
 
-	mock.ExpectQuery("^SELECT u.email FROM store_users AS su*").
+	s.mock.ExpectQuery("^SELECT u.email FROM store_users AS su*").
 		WithArgs(storeID, false).
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
 	args := map[string]interface{}{"storeId": storeID, "name": "My Renamed Store"}
-	store, err := UpdateStoreForUser(db, userID, args)
-	require.NoError(t, err)
+	store, err := UpdateStoreForUser(userID, args)
+	require.NoError(s.T(), err)
 	// Assert only completed state changed
-	assert.Equal(t, store.(*models.Store).ID, storeID)
-	assert.Equal(t, store.(*models.Store).UserID, userID)
-	assert.Equal(t, store.(*models.Store).Name, "My Renamed Store")
+	assert.Equal(s.T(), store.(*models.Store).ID, storeID)
+	assert.Equal(s.T(), store.(*models.Store).UserID, userID)
+	assert.Equal(s.T(), store.(*models.Store).Name, "My Renamed Store")
 }

--- a/internal/pkg/stores/user_stores.go
+++ b/internal/pkg/stores/user_stores.go
@@ -4,15 +4,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	uuid "github.com/satori/go.uuid"
-	"gorm.io/gorm"
 )
 
 // RetrieveUserStores retrieves stores that the userID has created or has been added to
-func RetrieveUserStores(db *gorm.DB, user models.User) ([]models.Store, error) {
+func RetrieveUserStores(user models.User) ([]models.Store, error) {
 	stores := []models.Store{}
-	query := db.
+	query := db.Manager.
 		Select("stores.*").
 		Joins("INNER JOIN store_users ON store_users.store_id = stores.id").
 		Joins("LEFT OUTER JOIN grocery_trips ON grocery_trips.store_id = stores.id").
@@ -28,9 +28,9 @@ func RetrieveUserStores(db *gorm.DB, user models.User) ([]models.Store, error) {
 }
 
 // RetrieveInvitedUserStores retrieves stores that the userID has created or has been added to
-func RetrieveInvitedUserStores(db *gorm.DB, user models.User) ([]models.Store, error) {
+func RetrieveInvitedUserStores(user models.User) ([]models.Store, error) {
 	stores := []models.Store{}
-	query := db.
+	query := db.Manager.
 		Select("stores.*").
 		Joins("INNER JOIN store_users ON store_users.store_id = stores.id").
 		Joins("LEFT OUTER JOIN grocery_trips ON grocery_trips.store_id = stores.id").
@@ -48,14 +48,14 @@ func RetrieveInvitedUserStores(db *gorm.DB, user models.User) ([]models.Store, e
 }
 
 // RetrieveStoreForUser retrieves a specific store by storeID and userID
-func RetrieveStoreForUser(db *gorm.DB, storeID interface{}, userID uuid.UUID) (models.Store, error) {
+func RetrieveStoreForUser(storeID interface{}, userID uuid.UUID) (models.Store, error) {
 	store := models.Store{}
-	if err := db.Where("id = ?", storeID).First(&store).Error; err != nil {
+	if err := db.Manager.Where("id = ?", storeID).First(&store).Error; err != nil {
 		return store, err
 	}
 	// Check that the passed userID is a member of this store
 	storeUser := &models.StoreUser{}
-	if err := db.Where("store_id = ? AND user_id = ?", storeID, userID).First(&storeUser).Error; err != nil {
+	if err := db.Manager.Where("store_id = ? AND user_id = ?", storeID, userID).First(&storeUser).Error; err != nil {
 		return store, err
 	}
 	return store, nil
@@ -64,9 +64,9 @@ func RetrieveStoreForUser(db *gorm.DB, storeID interface{}, userID uuid.UUID) (m
 // RetrieveStoreForUserByName retrieves a specific store by name and userID.
 // It is used in resolvers.CreateStoreResolver to determine whether a store with
 // a given name already exists in the user's account, to avoid duplicates.
-func RetrieveStoreForUserByName(db *gorm.DB, name string, userID uuid.UUID) (models.Store, error) {
+func RetrieveStoreForUserByName(name string, userID uuid.UUID) (models.Store, error) {
 	store := models.Store{}
-	if err := db.Where("name = ? AND user_id = ?", name, userID).First(&store).Error; err != nil {
+	if err := db.Manager.Where("name = ? AND user_id = ?", name, userID).First(&store).Error; err != nil {
 		return store, err
 	}
 	return store, nil
@@ -76,18 +76,18 @@ func RetrieveStoreForUserByName(db *gorm.DB, name string, userID uuid.UUID) (mod
 // and finally notifies the store users that the store has been deleted
 //
 // Note: this really performs a soft delete for stores and associated models
-func DeleteStore(db *gorm.DB, storeID interface{}, userID uuid.UUID) (models.Store, error) {
+func DeleteStore(storeID interface{}, userID uuid.UUID) (models.Store, error) {
 	store := models.Store{}
-	if err := db.Where("id = ? AND user_id = ?", storeID, userID).First(&store).Error; err != nil {
+	if err := db.Manager.Where("id = ? AND user_id = ?", storeID, userID).First(&store).Error; err != nil {
 		return store, errors.New("couldn't retrieve store")
 	}
-	if err := db.Delete(&store).Error; err != nil {
+	if err := db.Manager.Delete(&store).Error; err != nil {
 		return store, errors.New("couldn't delete store")
 	}
 
 	// Delete items in each trip in this store, and then delete the trips themselves
 	trips := []models.GroceryTrip{}
-	if err := db.Where("store_id = ?", storeID).Find(&trips).Error; err != nil {
+	if err := db.Manager.Where("store_id = ?", storeID).Find(&trips).Error; err != nil {
 		return store, errors.New("couldn't find trips in store")
 	}
 	for i := range trips {
@@ -97,23 +97,23 @@ func DeleteStore(db *gorm.DB, storeID interface{}, userID uuid.UUID) (models.Sto
 		// we don't need to do anything with the items after deletion.
 		// for store users we need to fetch, notify, and *then* delete
 		items := []models.Item{}
-		if err := db.Where("grocery_trip_id = ?", tripID).Delete(&items).Error; err != nil {
+		if err := db.Manager.Where("grocery_trip_id = ?", tripID).Delete(&items).Error; err != nil {
 			return store, errors.New("couldn't delete items in this store's trips")
 		}
 
 		trip := models.GroceryTrip{}
-		if err := db.Where("id = ?", tripID).Delete(&trip).Error; err != nil {
+		if err := db.Manager.Where("id = ?", tripID).Delete(&trip).Error; err != nil {
 			return store, fmt.Errorf("couldn't delete trip: %s", tripID)
 		}
 	}
 
 	storeUsers := []models.StoreUser{}
-	if err := db.Where("store_id = ?", storeID).Find(&storeUsers).Error; err != nil {
+	if err := db.Manager.Where("store_id = ?", storeID).Find(&storeUsers).Error; err != nil {
 		return store, errors.New("couldn't retrieve store users")
 	}
 
 	//TODO notify store users that store was deleted (except creator)
-	if err := db.Where("store_id = ?", storeID).Delete(&storeUsers).Error; err != nil {
+	if err := db.Manager.Where("store_id = ?", storeID).Delete(&storeUsers).Error; err != nil {
 		return store, errors.New("couldn't delete store users")
 	}
 

--- a/internal/pkg/stores/users.go
+++ b/internal/pkg/stores/users.go
@@ -3,19 +3,19 @@ package stores
 import (
 	"errors"
 
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/mailer"
 	uuid "github.com/satori/go.uuid"
-	"gorm.io/gorm"
 )
 
 // InviteToStoreByEmail creates a store_users record for this store ID and email
 //
 // The store user will be considered pending until the invitation is accepted
 // by the user in the app, at which point they are associated by userID instead.
-func InviteToStoreByEmail(db *gorm.DB, storeID interface{}, invitedEmail string) (models.StoreUser, error) {
+func InviteToStoreByEmail(storeID interface{}, invitedEmail string) (models.StoreUser, error) {
 	store := &models.Store{}
-	if err := db.Where("id = ?", storeID).First(&store).Error; err != nil {
+	if err := db.Manager.Where("id = ?", storeID).First(&store).Error; err != nil {
 		return models.StoreUser{}, err
 	}
 
@@ -25,7 +25,7 @@ func InviteToStoreByEmail(db *gorm.DB, storeID interface{}, invitedEmail string)
 		Email:   invitedEmail,
 		Active:  &storeUserActive,
 	}
-	if err := db.Where(storeUser).FirstOrCreate(&storeUser).Error; err != nil {
+	if err := db.Manager.Where(storeUser).FirstOrCreate(&storeUser).Error; err != nil {
 		return models.StoreUser{}, err
 	}
 	return storeUser, nil
@@ -33,14 +33,14 @@ func InviteToStoreByEmail(db *gorm.DB, storeID interface{}, invitedEmail string)
 
 // AddUserToStore properly associates a user with a store by userID by removing
 // the email value and adding the userID value
-func AddUserToStore(db *gorm.DB, user models.User, storeID interface{}) (interface{}, error) {
+func AddUserToStore(user models.User, storeID interface{}) (interface{}, error) {
 	store := &models.Store{}
-	if err := db.Where("id = ?", storeID).First(&store).Error; err != nil {
+	if err := db.Manager.Where("id = ?", storeID).First(&store).Error; err != nil {
 		return nil, err
 	}
 
 	storeUser := &models.StoreUser{}
-	updateStoreUserQuery := db.
+	updateStoreUserQuery := db.Manager.
 		Where("store_id = ? AND email = ?", storeID, user.Email).
 		Find(&storeUser).
 		Error
@@ -51,7 +51,7 @@ func AddUserToStore(db *gorm.DB, user models.User, storeID interface{}) (interfa
 	storeUser.UserID = user.ID
 	storeUserActive := true
 	storeUser.Active = &storeUserActive
-	if err := db.Save(&storeUser).Error; err != nil {
+	if err := db.Manager.Save(&storeUser).Error; err != nil {
 		return nil, err
 	}
 	return storeUser, nil
@@ -60,14 +60,14 @@ func AddUserToStore(db *gorm.DB, user models.User, storeID interface{}) (interfa
 // RemoveUserFromStore removes a user from a store either by userID or email, whichever is present
 //
 // Used for declining a store invite, and simply removing a user from a store
-func RemoveUserFromStore(db *gorm.DB, user models.User, storeID interface{}) (interface{}, error) {
+func RemoveUserFromStore(user models.User, storeID interface{}) (interface{}, error) {
 	store := &models.Store{}
-	if err := db.Where("id = ?", storeID).First(&store).Error; err != nil {
+	if err := db.Manager.Where("id = ?", storeID).First(&store).Error; err != nil {
 		return nil, errors.New("store not found")
 	}
 
 	storeUser := &models.StoreUser{}
-	query := db.
+	query := db.Manager.
 		Where("store_id = ?", storeID).
 		Where("user_id = ?", user.ID).
 		Or("email = ?", user.Email).
@@ -77,17 +77,17 @@ func RemoveUserFromStore(db *gorm.DB, user models.User, storeID interface{}) (in
 		return nil, errors.New("store user not found")
 	}
 
-	if err := db.Delete(&storeUser).Error; err != nil {
+	if err := db.Manager.Delete(&storeUser).Error; err != nil {
 		return nil, err
 	}
 
 	// Get the store creator StoreUser record and User record
 	creatorStoreUser := &models.StoreUser{}
-	if err := db.Select("user_id").Where("store_id = ? AND creator = ?", storeID, true).First(&creatorStoreUser).Error; err != nil {
+	if err := db.Manager.Select("user_id").Where("store_id = ? AND creator = ?", storeID, true).First(&creatorStoreUser).Error; err != nil {
 		return nil, err
 	}
 	creatorUser := &models.User{}
-	if err := db.Select("email").Where("id = ?", creatorStoreUser.UserID).First(&creatorUser).Error; err != nil {
+	if err := db.Manager.Select("email").Where("id = ?", creatorStoreUser.UserID).First(&creatorUser).Error; err != nil {
 		return nil, err
 	}
 
@@ -100,7 +100,7 @@ func RemoveUserFromStore(db *gorm.DB, user models.User, storeID interface{}) (in
 		}
 	} else {
 		storeUserUser := &models.User{}
-		if err := db.Select("email").Where("id = ?", storeUser.UserID).Find(&storeUserUser).Error; err != nil {
+		if err := db.Manager.Select("email").Where("id = ?", storeUser.UserID).Find(&storeUserUser).Error; err != nil {
 			return nil, err
 		}
 		_, err := mailer.SendUserLeftStoreEmail(store.Name, storeUserUser.Email, creatorUser.Email)
@@ -113,18 +113,18 @@ func RemoveUserFromStore(db *gorm.DB, user models.User, storeID interface{}) (in
 }
 
 // RetrieveStoreUsers finds all store users in a store by storeID5
-func RetrieveStoreUsers(db *gorm.DB, storeID uuid.UUID) (interface{}, error) {
+func RetrieveStoreUsers(storeID uuid.UUID) (interface{}, error) {
 	storeUsers := []models.StoreUser{}
-	if err := db.Where("store_id = ?", storeID).Order("created_at ASC").Find(&storeUsers).Error; err != nil {
+	if err := db.Manager.Where("store_id = ?", storeID).Order("created_at ASC").Find(&storeUsers).Error; err != nil {
 		return nil, err
 	}
 	return storeUsers, nil
 }
 
 // RetrieveStoreCreator returns the store user who created a given store
-func RetrieveStoreCreator(db *gorm.DB, storeID uuid.UUID) (interface{}, error) {
+func RetrieveStoreCreator(storeID uuid.UUID) (interface{}, error) {
 	storeUser := &models.StoreUser{}
-	query := db.
+	query := db.Manager.
 		Where("store_id = ?", storeID).
 		Where("creator = ?", true).
 		First(&storeUser).
@@ -134,7 +134,7 @@ func RetrieveStoreCreator(db *gorm.DB, storeID uuid.UUID) (interface{}, error) {
 	}
 
 	user := &models.User{}
-	if err := db.Where("id = ?", storeUser.UserID).First(&user).Error; err != nil {
+	if err := db.Manager.Where("id = ?", storeUser.UserID).First(&user).Error; err != nil {
 		return nil, err
 	}
 	return user, nil

--- a/internal/pkg/stores/users_test.go
+++ b/internal/pkg/stores/users_test.go
@@ -1,8 +1,6 @@
 package stores
 
 import (
-	"database/sql/driver"
-	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -10,111 +8,76 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
 )
 
-type AnyTime struct{}
-
-// Match satisfies sqlmock.Argument interface
-func (a AnyTime) Match(v driver.Value) bool {
-	_, ok := v.(time.Time)
-	return ok
-}
-
-func TestInviteToStoreByEmail_UserExistsNotYetAdded(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestInviteToStoreByEmail_UserExistsNotYetAdded() {
 	storeID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
 		WithArgs(storeID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(storeID))
 
 	email := "test@example.com"
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, email, false).
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
-	mock.ExpectQuery("^INSERT INTO \"store_users\" (.+)$").
+	s.mock.ExpectQuery("^INSERT INTO \"store_users\" (.+)$").
 		WithArgs(storeID, sqlmock.AnyArg(), email, false, false, AnyTime{}, AnyTime{}, nil).
 		WillReturnRows(sqlmock.NewRows([]string{"store_id"}).AddRow(storeID))
-	mock.ExpectQuery("^SELECT \"name\" FROM \"stores\"*").
+	s.mock.ExpectQuery("^SELECT \"name\" FROM \"stores\"*").
 		WithArgs(storeID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(storeID))
 
-	storeUser, err := InviteToStoreByEmail(db, storeID, email)
-	require.NoError(t, err)
-	assert.Equal(t, storeUser.Email, email)
+	storeUser, err := InviteToStoreByEmail(storeID, email)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), storeUser.Email, email)
 }
 
-func TestInviteToStoreByEmail_UserExistsAlreadyAdded(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestInviteToStoreByEmail_UserExistsAlreadyAdded() {
 	storeID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
 		WithArgs(storeID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(storeID))
 
 	email := "test@example.com"
 	storeUserID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, email, false).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(storeUserID))
 
-	storeUser, err := InviteToStoreByEmail(db, storeID, email)
-	require.NoError(t, err)
-	assert.Equal(t, storeUser.ID, storeUserID)
-	assert.Equal(t, storeUser.Email, email)
+	storeUser, err := InviteToStoreByEmail(storeID, email)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), storeUser.ID, storeUserID)
+	assert.Equal(s.T(), storeUser.Email, email)
 }
 
-func TestRemoveUserFromStore_StoreNotFound(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRemoveUserFromStore_StoreNotFound() {
 	storeID := uuid.NewV4()
 	user := models.User{ID: uuid.NewV4()}
-	mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
 		WithArgs(storeID).
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
-	_, e := RemoveUserFromStore(db, user, storeID)
-	require.Error(t, e)
-	assert.Equal(t, e.Error(), "store not found")
+	_, e := RemoveUserFromStore(user, storeID)
+	require.Error(s.T(), e)
+	assert.Equal(s.T(), e.Error(), "store not found")
 }
 
-func TestRemoveUserFromStore_StoreUserNotFound(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRemoveUserFromStore_StoreUserNotFound() {
 	storeID := uuid.NewV4()
 	user := models.User{ID: uuid.NewV4()}
-	mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
 		WithArgs(storeID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(storeID))
 
-	_, e := RemoveUserFromStore(db, user, storeID)
-	require.Error(t, e)
-	assert.Equal(t, e.Error(), "store user not found")
+	_, e := RemoveUserFromStore(user, storeID)
+	require.Error(s.T(), e)
+	assert.Equal(s.T(), e.Error(), "store user not found")
 }
 
-func TestRemoveUserFromStore_SuccessInvitedUser(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRemoveUserFromStore_SuccessInvitedUser() {
 	storeID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
 		WithArgs(storeID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(storeID))
 
@@ -127,39 +90,34 @@ func TestRemoveUserFromStore_SuccessInvitedUser(t *testing.T) {
 	rows := sqlmock.
 		NewRows([]string{"id", "email"}).
 		AddRow(storeUser.ID, storeUser.Email)
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, user.ID, user.Email).
 		WillReturnRows(rows)
 
-	mock.ExpectBegin()
-	mock.ExpectExec("UPDATE \"store_users\"*").
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec("UPDATE \"store_users\"*").
 		WithArgs(AnyTime{}, storeUser.ID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
+	s.mock.ExpectCommit()
 
 	// Test querying for data to send the email about invite being declined
 	creatorUserID := uuid.NewV4()
 	creatorUser := models.User{ID: creatorUserID, Email: "creator@example.com"}
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, true).
 		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow(creatorUserID))
-	mock.ExpectQuery("^SELECT \"email\" FROM \"users\"*").
+	s.mock.ExpectQuery("^SELECT \"email\" FROM \"users\"*").
 		WithArgs(creatorUserID).
 		WillReturnRows(sqlmock.NewRows([]string{"email"}).AddRow(creatorUser.Email))
 
-	lu, err := RemoveUserFromStore(db, user, storeID)
-	require.NoError(t, err)
-	assert.Equal(t, lu.(*models.StoreUser).ID, storeUser.ID)
+	lu, err := RemoveUserFromStore(user, storeID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), lu.(*models.StoreUser).ID, storeUser.ID)
 }
 
-func TestRemoveUserFromStore_SuccessJoinedStoreUser(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRemoveUserFromStore_SuccessJoinedStoreUser() {
 	storeID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
 		WithArgs(storeID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(storeID))
 
@@ -172,91 +130,76 @@ func TestRemoveUserFromStore_SuccessJoinedStoreUser(t *testing.T) {
 	rows := sqlmock.
 		NewRows([]string{"id", "user_id"}).
 		AddRow(storeUser.ID, storeUser.UserID)
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, user.ID, user.Email).
 		WillReturnRows(rows)
 
-	mock.ExpectBegin()
-	mock.ExpectExec("UPDATE \"store_users\"*").
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec("UPDATE \"store_users\"*").
 		WithArgs(AnyTime{}, storeUser.ID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
+	s.mock.ExpectCommit()
 
 	// Test querying for data to send the email about this user leaving the store
 	creatorUserID := uuid.NewV4()
 	creatorUser := models.User{ID: creatorUserID, Email: "creator@example.com"}
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, true).
 		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow(creatorUserID))
-	mock.ExpectQuery("^SELECT \"email\" FROM \"users\"*").
+	s.mock.ExpectQuery("^SELECT \"email\" FROM \"users\"*").
 		WithArgs(creatorUserID).
 		WillReturnRows(sqlmock.NewRows([]string{"email"}).AddRow(creatorUser.Email))
-	mock.ExpectQuery("^SELECT \"email\" FROM \"users\"*").
+	s.mock.ExpectQuery("^SELECT \"email\" FROM \"users\"*").
 		WithArgs(storeUser.UserID).
 		WillReturnRows(sqlmock.NewRows([]string{"email"}).AddRow(user.Email))
 
-	lu, err := RemoveUserFromStore(db, user, storeID)
-	require.NoError(t, err)
-	assert.Equal(t, lu.(*models.StoreUser).ID, storeUser.ID)
+	lu, err := RemoveUserFromStore(user, storeID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), lu.(*models.StoreUser).ID, storeUser.ID)
 }
 
-func TestAddUserToStore_UserNotFoundInStore(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestAddUserToStore_UserNotFoundInStore() {
 	storeID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
 		WithArgs(storeID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(storeID))
 
 	user := models.User{ID: uuid.NewV4(), Email: "test@example.com"}
 	storeUserID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, user.Email).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(storeUserID))
 
-	_, e := AddUserToStore(db, user, storeID)
-	require.Error(t, e)
+	_, e := AddUserToStore(user, storeID)
+	require.Error(s.T(), e)
 }
 
-func TestAddUserToStore_Success(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestAddUserToStore_Success() {
 	storeID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
 		WithArgs(storeID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(storeID))
 
 	email := "test@example.com"
 	user := models.User{ID: uuid.NewV4(), Email: email}
 	storeUserID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, user.Email).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "email"}).AddRow(storeUserID, email))
 
-	mock.ExpectBegin()
-	mock.ExpectExec("^UPDATE \"store_users\" SET (.+)$").
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec("^UPDATE \"store_users\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
+	s.mock.ExpectCommit()
 
-	storeUser, err := AddUserToStore(db, user, storeID)
-	require.NoError(t, err)
-	assert.Equal(t, storeUser.(*models.StoreUser).ID, storeUserID)
-	assert.Equal(t, storeUser.(*models.StoreUser).UserID, user.ID)
-	assert.Equal(t, storeUser.(*models.StoreUser).Email, "")
+	storeUser, err := AddUserToStore(user, storeID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), storeUser.(*models.StoreUser).ID, storeUserID)
+	assert.Equal(s.T(), storeUser.(*models.StoreUser).UserID, user.ID)
+	assert.Equal(s.T(), storeUser.(*models.StoreUser).Email, "")
 }
 
-func TestRetrieveStoreUsers_HasStoreUsers(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveStoreUsers_HasStoreUsers() {
 	storeID := uuid.NewV4()
 	store := &models.Store{
 		ID:        storeID,
@@ -277,22 +220,17 @@ func TestRetrieveStoreUsers_HasStoreUsers(t *testing.T) {
 		}).
 		AddRow(uuid.NewV4(), storeID, uuid.NewV4(), true, true, time.Now(), time.Now()).
 		AddRow(uuid.NewV4(), storeID, uuid.NewV4(), false, true, time.Now(), time.Now())
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID).
 		WillReturnRows(storeUserRows)
 
-	storeUsers, err := RetrieveStoreUsers(db, store.ID)
-	require.NoError(t, err)
-	assert.Equal(t, len(storeUsers.([]models.StoreUser)), 2)
-	assert.Equal(t, storeUsers.([]models.StoreUser)[0].StoreID, store.ID)
+	storeUsers, err := RetrieveStoreUsers(store.ID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), len(storeUsers.([]models.StoreUser)), 2)
+	assert.Equal(s.T(), storeUsers.([]models.StoreUser)[0].StoreID, store.ID)
 }
 
-func TestRetrieveStoreCreator_StoreUserNotFound(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveStoreCreator_StoreUserNotFound() {
 	storeID := uuid.NewV4()
 	store := &models.Store{
 		ID:        storeID,
@@ -302,21 +240,16 @@ func TestRetrieveStoreCreator_StoreUserNotFound(t *testing.T) {
 	}
 
 	//storeUser := &models.StoreUser{}
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, true).
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
-	_, e := RetrieveStoreCreator(db, store.ID)
-	require.Error(t, e)
-	assert.Equal(t, e.Error(), "record not found")
+	_, e := RetrieveStoreCreator(store.ID)
+	require.Error(s.T(), e)
+	assert.Equal(s.T(), e.Error(), "record not found")
 }
 
-func TestRetrieveStoreCreator_UserNotFound(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveStoreCreator_UserNotFound() {
 	storeID := uuid.NewV4()
 	store := &models.Store{
 		ID:        storeID,
@@ -336,24 +269,19 @@ func TestRetrieveStoreCreator_UserNotFound(t *testing.T) {
 		UserID:  user.ID,
 		Creator: &storeUserCreator,
 	}
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, true).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "creator"}).AddRow(storeUser.ID, user.ID, storeUser.Creator))
-	mock.ExpectQuery("^SELECT (.+) FROM \"users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"users\"*").
 		WithArgs(user.ID).
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
-	_, e := RetrieveStoreCreator(db, store.ID)
-	require.Error(t, e)
-	assert.Equal(t, e.Error(), "record not found")
+	_, e := RetrieveStoreCreator(store.ID)
+	require.Error(s.T(), e)
+	assert.Equal(s.T(), e.Error(), "record not found")
 }
 
-func TestRetrieveStoreCreator_Found(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveStoreCreator_Found() {
 	storeID := uuid.NewV4()
 	store := &models.Store{
 		ID:        storeID,
@@ -373,14 +301,14 @@ func TestRetrieveStoreCreator_Found(t *testing.T) {
 		UserID:  user.ID,
 		Creator: &storeUserCreator,
 	}
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, true).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "creator"}).AddRow(storeUser.ID, user.ID, storeUser.Creator))
-	mock.ExpectQuery("^SELECT (.+) FROM \"users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"users\"*").
 		WithArgs(user.ID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "email"}).AddRow(user.ID, user.Email))
 
-	creatorUser, err := RetrieveStoreCreator(db, store.ID)
-	require.NoError(t, err)
-	assert.Equal(t, creatorUser.(*models.User).Email, email)
+	creatorUser, err := RetrieveStoreCreator(store.ID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), creatorUser.(*models.User).Email, email)
 }

--- a/internal/pkg/trips/add_item.go
+++ b/internal/pkg/trips/add_item.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	uuid "github.com/satori/go.uuid"
 	"github.com/tidwall/gjson"
@@ -15,16 +16,16 @@ import (
 )
 
 // AddItem adds an item to a trip and handles things like permission checks
-func AddItem(db *gorm.DB, userID uuid.UUID, args map[string]interface{}) (interface{}, error) {
+func AddItem(userID uuid.UUID, args map[string]interface{}) (interface{}, error) {
 	tripID := args["tripId"]
 	trip := &models.GroceryTrip{}
-	if err := db.Where("id = ?", tripID).Find(&trip).Error; err != nil {
+	if err := db.Manager.Where("id = ?", tripID).Find(&trip).Error; err != nil {
 		return nil, err
 	}
 
 	// Verify that the current user belongs to this store
 	storeUser := &models.StoreUser{}
-	if err := db.Where("store_id = ? AND user_id = ?", trip.StoreID, userID).First(&storeUser).Error; err != nil {
+	if err := db.Manager.Where("store_id = ? AND user_id = ?", trip.StoreID, userID).First(&storeUser).Error; err != nil {
 		return nil, err
 	}
 
@@ -49,13 +50,13 @@ func AddItem(db *gorm.DB, userID uuid.UUID, args map[string]interface{}) (interf
 		categoryName = DetermineCategoryName(itemName)
 	}
 
-	category, err := FetchGroceryTripCategory(db, trip.ID, categoryName)
+	category, err := FetchGroceryTripCategory(trip.ID, categoryName)
 	if err != nil {
 		return nil, err
 	}
 	item.CategoryID = &category.ID
 
-	if err := db.Create(&item).Error; err != nil {
+	if err := db.Manager.Create(&item).Error; err != nil {
 		return nil, err
 	}
 	return item, nil
@@ -65,9 +66,9 @@ func AddItem(db *gorm.DB, userID uuid.UUID, args map[string]interface{}) (interf
 
 // FetchGroceryTripCategory retrieves a grocery trip category for a new item by
 // finding or creating a category depending on if one exists by the name provided
-func FetchGroceryTripCategory(db *gorm.DB, tripID uuid.UUID, name string) (models.GroceryTripCategory, error) {
+func FetchGroceryTripCategory(tripID uuid.UUID, name string) (models.GroceryTripCategory, error) {
 	category := models.GroceryTripCategory{}
-	query := db.
+	query := db.Manager.
 		Select("grocery_trip_categories.id").
 		Joins("INNER JOIN store_categories ON store_categories.id = grocery_trip_categories.store_category_id").
 		Where("grocery_trip_categories.grocery_trip_id = ?", tripID).
@@ -75,7 +76,7 @@ func FetchGroceryTripCategory(db *gorm.DB, tripID uuid.UUID, name string) (model
 		First(&category).
 		Error
 	if err := query; errors.Is(err, gorm.ErrRecordNotFound) {
-		newCategory, err := CreateGroceryTripCategory(db, tripID, name)
+		newCategory, err := CreateGroceryTripCategory(tripID, name)
 		if err != nil {
 			return models.GroceryTripCategory{}, errors.New("could not find or create grocery trip category")
 		}
@@ -85,9 +86,9 @@ func FetchGroceryTripCategory(db *gorm.DB, tripID uuid.UUID, name string) (model
 }
 
 // CreateGroceryTripCategory creates a grocery trip category by name
-func CreateGroceryTripCategory(db *gorm.DB, tripID uuid.UUID, name string) (models.GroceryTripCategory, error) {
+func CreateGroceryTripCategory(tripID uuid.UUID, name string) (models.GroceryTripCategory, error) {
 	storeCategory := models.StoreCategory{}
-	query := db.Select("id").Where("name = ?", name).First(&storeCategory).Error
+	query := db.Manager.Select("id").Where("name = ?", name).First(&storeCategory).Error
 	if err := query; err != nil {
 		return models.GroceryTripCategory{}, err
 	}
@@ -95,7 +96,7 @@ func CreateGroceryTripCategory(db *gorm.DB, tripID uuid.UUID, name string) (mode
 		GroceryTripID:   tripID,
 		StoreCategoryID: storeCategory.ID,
 	}
-	if err := db.Create(&newCategory).Error; err != nil {
+	if err := db.Manager.Create(&newCategory).Error; err != nil {
 		return models.GroceryTripCategory{}, err
 	}
 	return newCategory, nil

--- a/internal/pkg/trips/delete_item.go
+++ b/internal/pkg/trips/delete_item.go
@@ -3,30 +3,30 @@ package trips
 import (
 	"errors"
 
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
-	"gorm.io/gorm"
 )
 
 // DeleteItem deletes an item from a trip and handles trip category cleanup
 // (i.e. if this is the last item in a trip category, it deletes the trip category)
-func DeleteItem(db *gorm.DB, itemID interface{}) (interface{}, error) {
+func DeleteItem(itemID interface{}) (interface{}, error) {
 	item := models.Item{}
-	if err := db.Where("id = ?", itemID).First(&item).Error; err != nil {
+	if err := db.Manager.Where("id = ?", itemID).First(&item).Error; err != nil {
 		return nil, errors.New("item not found")
 	}
 
 	categoryID := item.CategoryID
-	if err := db.Delete(&item).Error; err != nil {
+	if err := db.Manager.Delete(&item).Error; err != nil {
 		return nil, err
 	}
 
 	// If this was the last item in this trip category, delete the trip category too
 	var remainingItemsCount int64
-	if err := db.Model(&models.Item{}).Where("category_id = ?", categoryID).Count(&remainingItemsCount).Error; err != nil {
+	if err := db.Manager.Model(&models.Item{}).Where("category_id = ?", categoryID).Count(&remainingItemsCount).Error; err != nil {
 		return nil, err
 	}
 	if remainingItemsCount == 0 {
-		if err := db.Where("id = ?", categoryID).Delete(&models.GroceryTripCategory{}).Error; err != nil {
+		if err := db.Manager.Where("id = ?", categoryID).Delete(&models.GroceryTripCategory{}).Error; err != nil {
 			return nil, err
 		}
 	}

--- a/internal/pkg/trips/delete_item_test.go
+++ b/internal/pkg/trips/delete_item_test.go
@@ -1,90 +1,71 @@
 package trips
 
 import (
-	"testing"
-
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
 )
 
-func TestDeleteItem_ItemNotFound(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestDeleteItem_ItemNotFound() {
 	itemID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
 		WithArgs(itemID).
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
-	_, e := DeleteItem(db, itemID)
-	require.Error(t, e)
-	assert.Equal(t, e.Error(), "item not found")
+	_, e := DeleteItem(itemID)
+	require.Error(s.T(), e)
+	assert.Equal(s.T(), e.Error(), "item not found")
 }
 
-func TestDeleteItem_SuccessMoreInCategory(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestDeleteItem_SuccessMoreInCategory() {
 	itemID := uuid.NewV4()
 	categoryID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
 		WithArgs(itemID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "category_id"}).AddRow(itemID, categoryID))
 
-	mock.ExpectBegin()
-	mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("^UPDATE \"grocery_trips\" SET (.+)$").
+	s.mock.ExpectExec("^UPDATE \"grocery_trips\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
+	s.mock.ExpectCommit()
 
-	mock.ExpectQuery("^SELECT count*").
+	s.mock.ExpectQuery("^SELECT count*").
 		WithArgs(categoryID).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 
-	item, err := DeleteItem(db, itemID)
-	require.NoError(t, err)
-	assert.Equal(t, item.(models.Item).ID, itemID)
+	item, err := DeleteItem(itemID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), item.(models.Item).ID, itemID)
 }
 
-func TestDeleteItem_SuccessLastInCategory(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestDeleteItem_SuccessLastInCategory() {
 	itemID := uuid.NewV4()
 	categoryID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
 		WithArgs(itemID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "category_id"}).AddRow(itemID, categoryID))
 
-	mock.ExpectBegin()
-	mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("^UPDATE \"grocery_trips\" SET (.+)$").
+	s.mock.ExpectExec("^UPDATE \"grocery_trips\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
+	s.mock.ExpectCommit()
 
-	mock.ExpectQuery("^SELECT count*").
+	s.mock.ExpectQuery("^SELECT count*").
 		WithArgs(categoryID).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
-	mock.ExpectBegin()
-	mock.ExpectExec("^UPDATE \"grocery_trip_categories\" SET (.+)$").
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec("^UPDATE \"grocery_trip_categories\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
+	s.mock.ExpectCommit()
 
-	item, err := DeleteItem(db, itemID)
-	require.NoError(t, err)
-	assert.Equal(t, item.(models.Item).ID, itemID)
+	item, err := DeleteItem(itemID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), item.(models.Item).ID, itemID)
 }

--- a/internal/pkg/trips/items.go
+++ b/internal/pkg/trips/items.go
@@ -1,15 +1,15 @@
 package trips
 
 import (
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	uuid "github.com/satori/go.uuid"
-	"gorm.io/gorm"
 )
 
 // RetrieveItems finds all items in a grocery trip by tripID
-func RetrieveItems(db *gorm.DB, tripID uuid.UUID) (interface{}, error) {
+func RetrieveItems(tripID uuid.UUID) (interface{}, error) {
 	items := []models.Item{}
-	query := db.
+	query := db.Manager.
 		Where("grocery_trip_id = ?", tripID).
 		Order("position ASC").
 		Find(&items).
@@ -21,9 +21,9 @@ func RetrieveItems(db *gorm.DB, tripID uuid.UUID) (interface{}, error) {
 }
 
 // RetrieveItemsInCategory finds all items in a grocery trip by category
-func RetrieveItemsInCategory(db *gorm.DB, tripID uuid.UUID, categoryID uuid.UUID) (interface{}, error) {
+func RetrieveItemsInCategory(tripID uuid.UUID, categoryID uuid.UUID) (interface{}, error) {
 	items := []models.Item{}
-	query := db.
+	query := db.Manager.
 		Where("grocery_trip_id = ?", tripID).
 		Where("category_id = ?", categoryID).
 		Order("position ASC").

--- a/internal/pkg/trips/items_test.go
+++ b/internal/pkg/trips/items_test.go
@@ -1,7 +1,6 @@
 package trips
 
 import (
-	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -9,32 +8,20 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
 )
 
-func TestRetrieveItems_NoItems(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveItems_NoItems() {
 	tripID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
 		WithArgs(tripID).
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
-	items, err := RetrieveItems(db, tripID)
-	require.NoError(t, err)
-	assert.Equal(t, len(items.([]models.Item)), 0)
+	items, err := RetrieveItems(tripID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), len(items.([]models.Item)), 0)
 }
 
-func TestRetrieveItems_HasItems(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveItems_HasItems() {
 	tripID := uuid.NewV4()
 	itemRows := sqlmock.
 		NewRows([]string{
@@ -48,41 +35,31 @@ func TestRetrieveItems_HasItems(t *testing.T) {
 		}).
 		AddRow(uuid.NewV4(), tripID, "Apples", 5, false, time.Now(), time.Now()).
 		AddRow(uuid.NewV4(), tripID, "Bananas", 2, false, time.Now(), time.Now())
-	mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
 		WithArgs(tripID).
 		WillReturnRows(itemRows)
 
-	items, err := RetrieveItems(db, tripID)
-	require.NoError(t, err)
-	assert.Equal(t, len(items.([]models.Item)), 2)
-	assert.Equal(t, items.([]models.Item)[0].GroceryTripID, tripID)
-	assert.Equal(t, items.([]models.Item)[0].Name, "Apples")
-	assert.Equal(t, items.([]models.Item)[1].Name, "Bananas")
+	items, err := RetrieveItems(tripID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), len(items.([]models.Item)), 2)
+	assert.Equal(s.T(), items.([]models.Item)[0].GroceryTripID, tripID)
+	assert.Equal(s.T(), items.([]models.Item)[0].Name, "Apples")
+	assert.Equal(s.T(), items.([]models.Item)[1].Name, "Bananas")
 }
 
-func TestRetrieveItemsInCategory_NoItems(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveItemsInCategory_NoItems() {
 	tripID := uuid.NewV4()
 	categoryID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
 		WithArgs(tripID, categoryID).
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
-	items, err := RetrieveItemsInCategory(db, tripID, categoryID)
-	require.NoError(t, err)
-	assert.Equal(t, len(items.([]models.Item)), 0)
+	items, err := RetrieveItemsInCategory(tripID, categoryID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), len(items.([]models.Item)), 0)
 }
 
-func TestRetrieveItemsInCategory_HasItems(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveItemsInCategory_HasItems() {
 	tripID := uuid.NewV4()
 	categoryID := uuid.NewV4()
 	itemRows := sqlmock.
@@ -97,14 +74,14 @@ func TestRetrieveItemsInCategory_HasItems(t *testing.T) {
 		}).
 		AddRow(uuid.NewV4(), tripID, "Apples", 5, false, time.Now(), time.Now()).
 		AddRow(uuid.NewV4(), tripID, "Bananas", 2, false, time.Now(), time.Now())
-	mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
 		WithArgs(tripID, categoryID).
 		WillReturnRows(itemRows)
 
-	items, err := RetrieveItemsInCategory(db, tripID, categoryID)
-	require.NoError(t, err)
-	assert.Equal(t, len(items.([]models.Item)), 2)
-	assert.Equal(t, items.([]models.Item)[0].GroceryTripID, tripID)
-	assert.Equal(t, items.([]models.Item)[0].Name, "Apples")
-	assert.Equal(t, items.([]models.Item)[1].Name, "Bananas")
+	items, err := RetrieveItemsInCategory(tripID, categoryID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), len(items.([]models.Item)), 2)
+	assert.Equal(s.T(), items.([]models.Item)[0].GroceryTripID, tripID)
+	assert.Equal(s.T(), items.([]models.Item)[0].Name, "Apples")
+	assert.Equal(s.T(), items.([]models.Item)[1].Name, "Bananas")
 }

--- a/internal/pkg/trips/reorder_item.go
+++ b/internal/pkg/trips/reorder_item.go
@@ -1,23 +1,23 @@
 package trips
 
 import (
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
-	"gorm.io/gorm"
 )
 
 // ReorderItem handles the reordering of an item by taking the
 // item ID and the new position. It returns the reordered trip object.
-func ReorderItem(db *gorm.DB, itemID interface{}, position int) (*models.GroceryTrip, error) {
+func ReorderItem(itemID interface{}, position int) (*models.GroceryTrip, error) {
 	trip := &models.GroceryTrip{}
 	item := &models.Item{}
-	if err := db.Where("id = ?", itemID).First(&item).Error; err != nil {
+	if err := db.Manager.Where("id = ?", itemID).First(&item).Error; err != nil {
 		return trip, err
 	}
 	item.Position = position
-	if err := db.Save(&item).Error; err != nil {
+	if err := db.Manager.Save(&item).Error; err != nil {
 		return trip, err
 	}
-	if err := db.Where("id = ?", item.GroceryTripID).Find(&trip).Error; err != nil {
+	if err := db.Manager.Where("id = ?", item.GroceryTripID).Find(&trip).Error; err != nil {
 		return trip, err
 	}
 	return trip, nil

--- a/internal/pkg/trips/reorder_item_test.go
+++ b/internal/pkg/trips/reorder_item_test.go
@@ -1,44 +1,35 @@
 package trips
 
 import (
-	"testing"
-
 	"github.com/DATA-DOG/go-sqlmock"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
 )
 
-func TestReorderItem_ReorderItemPosition(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestReorderItem_ReorderItemPosition() {
 	itemID := uuid.NewV4()
 	tripID := uuid.NewV4()
 
-	mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
 		WithArgs(itemID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "grocery_trip_id"}).AddRow(itemID, tripID))
 
-	mock.ExpectBegin()
-	mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+	s.mock.ExpectBegin()
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
 		WithArgs(itemID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(itemID))
-	mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
+	s.mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("^UPDATE \"grocery_trips\" SET (.+)$").
+	s.mock.ExpectExec("^UPDATE \"grocery_trips\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
+	s.mock.ExpectCommit()
 
-	mock.ExpectQuery("^SELECT (.+) FROM \"grocery_trips\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"grocery_trips\"*").
 		WithArgs(tripID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(tripID))
 
-	trip, err := ReorderItem(db, itemID, 4)
-	require.NoError(t, err)
-	assert.Equal(t, trip.ID, tripID)
+	trip, err := ReorderItem(itemID, 4)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), trip.ID, tripID)
 }

--- a/internal/pkg/trips/trips.go
+++ b/internal/pkg/trips/trips.go
@@ -3,16 +3,16 @@ package trips
 import (
 	"errors"
 
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 
 	uuid "github.com/satori/go.uuid"
-	"gorm.io/gorm"
 )
 
 // RetrieveCurrentStoreTrip retrieves the currently active grocery trip in a
 // store by storeID if the userID has access to to the store
-func RetrieveCurrentStoreTrip(db *gorm.DB, storeID uuid.UUID, user models.User) (interface{}, error) {
-	query := db.
+func RetrieveCurrentStoreTrip(storeID uuid.UUID, user models.User) (interface{}, error) {
+	query := db.Manager.
 		Where("store_id = ?", storeID).
 		Where("user_id = ? OR email = ?", user.ID, user.Email).
 		Find(&models.StoreUser{}).
@@ -22,17 +22,17 @@ func RetrieveCurrentStoreTrip(db *gorm.DB, storeID uuid.UUID, user models.User) 
 	}
 
 	trip := models.GroceryTrip{}
-	if err := db.Where("store_id = ? AND completed = ?", storeID, false).Order("created_at DESC").Find(&trip).Error; err != nil {
+	if err := db.Manager.Where("store_id = ? AND completed = ?", storeID, false).Order("created_at DESC").Find(&trip).Error; err != nil {
 		return nil, errors.New("could not find trip associated with this store")
 	}
 	return trip, nil
 }
 
 // RetrieveTrip retrieves a specific grocery trip by ID
-func RetrieveTrip(db *gorm.DB, tripID interface{}) (models.GroceryTrip, error) {
+func RetrieveTrip(tripID interface{}) (models.GroceryTrip, error) {
 	trip := models.GroceryTrip{}
 
-	if err := db.Where("id = ?", tripID).First(&trip).Error; err != nil {
+	if err := db.Manager.Where("id = ?", tripID).First(&trip).Error; err != nil {
 		return trip, errors.New("trip not found")
 	}
 	return trip, nil

--- a/internal/pkg/trips/trips_test.go
+++ b/internal/pkg/trips/trips_test.go
@@ -1,102 +1,113 @@
 package trips
 
 import (
+	"database/sql"
+	"database/sql/driver"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
-func TestRetrieveCurrentStoreTrip_UserNotAMemberOfStore(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
+type AnyTime struct{}
 
+// Match satisfies sqlmock.Argument interface
+func (a AnyTime) Match(v driver.Value) bool {
+	_, ok := v.(time.Time)
+	return ok
+}
+
+type Suite struct {
+	suite.Suite
+
+	DB   *gorm.DB
+	mock sqlmock.Sqlmock
+}
+
+func (s *Suite) SetupSuite() {
+	var (
+		dbMock *sql.DB
+		err    error
+	)
+
+	dbMock, s.mock, err = sqlmock.New()
+	require.NoError(s.T(), err)
+	s.DB, err = gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
+	require.NoError(s.T(), err)
+
+	db.Manager = s.DB
+}
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, new(Suite))
+}
+
+func (s *Suite) TestRetrieveCurrentStoreTrip_UserNotMemberOfStore() {
 	storeID := uuid.NewV4()
 	user := models.User{ID: uuid.NewV4()}
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
-		WithArgs(storeID, user.ID).
-		WillReturnRows(sqlmock.NewRows([]string{}))
-
-	_, e := RetrieveCurrentStoreTrip(db, storeID, user)
-	require.Error(t, e)
-	assert.Equal(t, e.Error(), "user is not a member of this store")
+	result, err := RetrieveCurrentStoreTrip(storeID, user)
+	require.Error(s.T(), err)
+	assert.Nil(s.T(), result)
+	assert.Equal(s.T(), err.Error(), "user is not a member of this store")
 }
 
-func TestRetrieveCurrentStoreTrip_TripNotAssociatedWithStore(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveCurrentStoreTrip_TripNotAssociatedWithStore() {
 	storeID := uuid.NewV4()
 	user := models.User{ID: uuid.NewV4(), Email: "test@example.com"}
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, user.ID, user.Email).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
+		WillReturnRows(s.mock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
 
-	_, e := RetrieveCurrentStoreTrip(db, storeID, user)
-	require.Error(t, e)
-	assert.Equal(t, e.Error(), "could not find trip associated with this store")
+	result, err := RetrieveCurrentStoreTrip(storeID, user)
+	require.Error(s.T(), err)
+	assert.Nil(s.T(), result)
+	assert.Equal(s.T(), err.Error(), "could not find trip associated with this store")
 }
 
-func TestRetrieveCurrentStoreTrip_FoundResult(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveCurrentStoreTrip_FoundResult() {
 	storeID := uuid.NewV4()
 	user := models.User{ID: uuid.NewV4(), Email: "test@example.com"}
-	mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, user.ID, user.Email).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).AddRow(uuid.NewV4(), user.ID))
+		WillReturnRows(s.mock.NewRows([]string{"id", "user_id"}).AddRow(uuid.NewV4(), user.ID))
 
 	tripID := uuid.NewV4()
 	tripName := "Week of May 31"
-	mock.ExpectQuery("^SELECT (.+) FROM \"grocery_trips\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"grocery_trips\"*").
 		WithArgs(storeID, false).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(tripID, tripName))
+		WillReturnRows(s.mock.NewRows([]string{"id", "name"}).AddRow(tripID, tripName))
 
-	trip, err := RetrieveCurrentStoreTrip(db, storeID, user)
-	require.NoError(t, err)
-	assert.Equal(t, trip.(models.GroceryTrip).Name, tripName)
+	trip, err := RetrieveCurrentStoreTrip(storeID, user)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), trip.(models.GroceryTrip).Name, tripName)
 }
 
-func TestRetrieveTrip_NotFound(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveTrip_NotFound() {
 	tripID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"grocery_trips\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"grocery_trips\"*").
 		WithArgs(tripID).
-		WillReturnRows(sqlmock.NewRows([]string{}))
+		WillReturnRows(s.mock.NewRows([]string{}))
 
-	_, e := RetrieveTrip(db, tripID)
-	require.Error(t, e)
-	assert.Equal(t, e.Error(), "trip not found")
+	_, e := RetrieveTrip(tripID)
+	require.Error(s.T(), e)
+	assert.Equal(s.T(), e.Error(), "trip not found")
 }
 
-func TestRetrieveTrip_Found(t *testing.T) {
-	dbMock, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
-	require.NoError(t, err)
-
+func (s *Suite) TestRetrieveTrip_Found() {
 	tripID := uuid.NewV4()
-	mock.ExpectQuery("^SELECT (.+) FROM \"grocery_trips\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"grocery_trips\"*").
 		WithArgs(tripID).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(tripID))
+		WillReturnRows(s.mock.NewRows([]string{"id"}).AddRow(tripID))
 
-	trip, err := RetrieveTrip(db, tripID)
-	require.NoError(t, err)
-	assert.Equal(t, trip.ID, tripID)
+	trip, err := RetrieveTrip(tripID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), trip.ID, tripID)
 }

--- a/internal/pkg/trips/update_item.go
+++ b/internal/pkg/trips/update_item.go
@@ -1,15 +1,15 @@
 package trips
 
 import (
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 	uuid "github.com/satori/go.uuid"
-	"gorm.io/gorm"
 )
 
 // UpdateItem updates an item by itemID
-func UpdateItem(db *gorm.DB, args map[string]interface{}) (interface{}, error) {
+func UpdateItem(args map[string]interface{}) (interface{}, error) {
 	item := &models.Item{}
-	if err := db.Where("id = ?", args["itemId"]).First(&item).Error; err != nil {
+	if err := db.Manager.Where("id = ?", args["itemId"]).First(&item).Error; err != nil {
 		return nil, err
 	}
 
@@ -31,20 +31,20 @@ func UpdateItem(db *gorm.DB, args map[string]interface{}) (interface{}, error) {
 		categoryID := args["categoryId"].(uuid.UUID)
 		item.CategoryID = &categoryID
 	}
-	if err := db.Save(&item).Error; err != nil {
+	if err := db.Manager.Save(&item).Error; err != nil {
 		return nil, err
 	}
 	return item, nil
 }
 
 // GetNewPosition gets the new position of an updated item
-func GetNewPosition(db *gorm.DB, tripID uuid.UUID, completed bool) int {
+func GetNewPosition(tripID uuid.UUID, completed bool) int {
 	newPosition := 1
 	if completed {
 		// If the item was marked completed, move to the bottom of the store
 		// The BeforeUpdate hook on items will handle reordering the items around it
 		bottomItem := &models.Item{}
-		db.
+		db.Manager.
 			Select("position").
 			Where("grocery_trip_id = ?", tripID).
 			Order("position DESC").

--- a/internal/pkg/trips/update_trip.go
+++ b/internal/pkg/trips/update_trip.go
@@ -1,14 +1,14 @@
 package trips
 
 import (
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
-	"gorm.io/gorm"
 )
 
 // UpdateTrip updates a grocery trip with the given args by tripID
-func UpdateTrip(db *gorm.DB, args map[string]interface{}) (interface{}, error) {
+func UpdateTrip(args map[string]interface{}) (interface{}, error) {
 	trip := models.GroceryTrip{}
-	if err := db.Where("id = ?", args["tripId"]).First(&trip).Error; err != nil {
+	if err := db.Manager.Where("id = ?", args["tripId"]).First(&trip).Error; err != nil {
 		return nil, err
 	}
 	if args["name"] != nil {
@@ -20,7 +20,7 @@ func UpdateTrip(db *gorm.DB, args map[string]interface{}) (interface{}, error) {
 	if args["copyRemainingItems"] != nil {
 		trip.CopyRemainingItems = args["copyRemainingItems"].(bool)
 	}
-	if err := db.Save(&trip).Error; err != nil {
+	if err := db.Manager.Save(&trip).Error; err != nil {
 		return nil, err
 	}
 	return trip, nil

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bradpurchase/grocerytime-backend/handlers"
 
 	// Autoload env variables from .env
-
 	_ "github.com/joho/godotenv/autoload"
 
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
@@ -19,7 +18,6 @@ import (
 )
 
 func main() {
-	// Establish a DB factory so we can automatically run migrations etc on load
 	db.Factory()
 
 	router := mux.NewRouter().StrictSlash(true)


### PR DESCRIPTION
This was a major pain in the ass, but resulted in a MUCH cleaner codebase and test suite.

> Gorm V2 has exposed that I was opening and closing database connections instead of using a database pool. Specifically, V2 removes `db.Close()` and now I am opening many connections without closing them. Fun!