### PR TITLE
No longer create a default store on user signup

### DIFF
--- a/internal/pkg/auth/create_user.go
+++ b/internal/pkg/auth/create_user.go
@@ -20,12 +20,7 @@ func CreateUser(email string, password string, name string, clientID uuid.UUID) 
 
 	// Check for dupe email
 	var dupeCount int64
-	existsQuery := db.Manager.
-		Model(&models.User{}).
-		Where("email = ?", email).
-		Count(&dupeCount).
-		Error
-	if err := existsQuery; err != nil {
+	if err := db.Manager.Model(&models.User{}).Where("email = ?", email).Count(&dupeCount).Error; err != nil {
 		return nil, err
 	}
 	if dupeCount > 0 {

--- a/internal/pkg/auth/create_user.go
+++ b/internal/pkg/auth/create_user.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/mailer"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/crypto/bcrypt"
-	"gorm.io/gorm"
 )
 
 // CreateUser creates a user account with details provided
@@ -19,9 +18,17 @@ func CreateUser(email string, password string, name string, clientID uuid.UUID) 
 		return nil, err
 	}
 
-	// Handle dupe email
-	dupeUser := &models.User{}
-	if err := db.Manager.Where("email = ?", email).First(&dupeUser).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+	// Check for dupe email
+	var dupeCount int64
+	existsQuery := db.Manager.
+		Model(&models.User{}).
+		Where("email = ?", email).
+		Count(&dupeCount).
+		Error
+	if err := existsQuery; err != nil {
+		return nil, err
+	}
+	if dupeCount > 0 {
 		return nil, errors.New("An account with this email address already exists")
 	}
 

--- a/internal/pkg/auth/create_user_test.go
+++ b/internal/pkg/auth/create_user_test.go
@@ -16,7 +16,7 @@ func (s *Suite) TestCreateUser_DuplicateEmail() {
 	email := "test@example.com"
 	s.mock.ExpectQuery("^SELECT (.+) FROM \"users\"*").
 		WithArgs(email).
-		WillReturnRows(sqlmock.NewRows([]string{"email"}).AddRow(email))
+		WillReturnRows(sqlmock.NewRows([]string{"count(1)"}).AddRow(1))
 
 	_, e := CreateUser(email, "password", "John", uuid.NewV4())
 	require.Error(s.T(), e)
@@ -25,14 +25,12 @@ func (s *Suite) TestCreateUser_DuplicateEmail() {
 
 func (s *Suite) TestCreateUser_UserCreated() {
 	email := "test@example.com"
-	name := "John Doe"
-	storeName := "My Grocery Store"
-
 	s.mock.ExpectQuery("^SELECT (.+) FROM \"users\"*").
 		WithArgs(email).
-		WillReturnRows(sqlmock.NewRows([]string{}))
+		WillReturnRows(sqlmock.NewRows([]string{"count(1)"}).AddRow(0))
 
 	userID := uuid.NewV4()
+	name := "John Doe"
 	s.mock.ExpectQuery("^INSERT INTO \"users\" (.+)$").
 		WithArgs(email, sqlmock.AnyArg(), name, AnyTime{}, AnyTime{}, AnyTime{}).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(userID))
@@ -42,54 +40,8 @@ func (s *Suite) TestCreateUser_UserCreated() {
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), AnyTime{}, AnyTime{}, AnyTime{}, sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "client_id", "user_id"}).AddRow(uuid.NewV4(), clientID, userID))
 
-	storeID := uuid.NewV4()
-	s.mock.ExpectQuery("^INSERT INTO \"stores\" (.+)$").
-		WithArgs(storeName, AnyTime{}, AnyTime{}, nil, userID).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).AddRow(storeID, userID))
-	s.mock.ExpectQuery("^INSERT INTO \"store_users\" (.+)$").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "", true, true, AnyTime{}, AnyTime{}, nil).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
-
-	categories := fetchCategories()
-	for i := range categories {
-		s.mock.ExpectQuery("^INSERT INTO \"store_categories\" (.+)$").
-			WithArgs(sqlmock.AnyArg(), categories[i], AnyTime{}, AnyTime{}, nil).
-			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
-	}
-
-	s.mock.ExpectQuery("^INSERT INTO \"grocery_trips\" (.+)$").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), false, false, AnyTime{}, AnyTime{}, nil).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
-
 	user, err := CreateUser(email, "password", name, clientID)
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), user.Email, email)
 	assert.NotNil(s.T(), user.Tokens)
-}
-
-// TODO: duplicated code with the store model... DRY this up
-func fetchCategories() [20]string {
-	categories := [20]string{
-		"Produce",
-		"Bakery",
-		"Meat",
-		"Seafood",
-		"Dairy",
-		"Cereal",
-		"Baking",
-		"Dry Goods",
-		"Canned Goods",
-		"Frozen Foods",
-		"Cleaning",
-		"Paper Products",
-		"Beverages",
-		"Candy & Snacks",
-		"Condiments",
-		"Personal Care",
-		"Baby",
-		"Alcohol",
-		"Pharmacy",
-		"Misc.",
-	}
-	return categories
 }

--- a/internal/pkg/auth/create_user_test.go
+++ b/internal/pkg/auth/create_user_test.go
@@ -43,5 +43,6 @@ func (s *Suite) TestCreateUser_UserCreated() {
 	user, err := CreateUser(email, "password", name, clientID)
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), user.Email, email)
+	assert.Equal(s.T(), user.Name, name)
 	assert.NotNil(s.T(), user.Tokens)
 }

--- a/internal/pkg/db/models/user.go
+++ b/internal/pkg/db/models/user.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	uuid "github.com/satori/go.uuid"
-	"gorm.io/gorm"
 )
 
 type User struct {
@@ -20,15 +19,4 @@ type User struct {
 	// Associations
 	Stores []Store
 	Tokens []AuthToken
-}
-
-// AfterCreate hook to automatically create some associated records
-func (u *User) AfterCreate(tx *gorm.DB) (err error) {
-	// Create default store
-	store := Store{UserID: u.ID, Name: "My Grocery Store"}
-	if err := tx.Create(&store).Error; err != nil {
-		return err
-	}
-
-	return
 }

--- a/internal/pkg/gql/types/user.go
+++ b/internal/pkg/gql/types/user.go
@@ -19,10 +19,7 @@ var UserType = graphql.NewObject(
 			"email": &graphql.Field{
 				Type: graphql.NewNonNull(graphql.String),
 			},
-			"firstName": &graphql.Field{
-				Type: graphql.String,
-			},
-			"lastName": &graphql.Field{
+			"name": &graphql.Field{
 				Type: graphql.String,
 			},
 			"createdAt": &graphql.Field{


### PR DESCRIPTION
Instead of creating a default store "My Grocery Store" on signup, we'll instead ask the user where they shop for groceries as part of an improved first run experience. This way the user will get a better sense of how the app works, and their first store in the app will have their actual store's name instead of a placeholder.