### PR TITLE
Refactor how copyRemainingItems works to factor in categories

### DIFF
--- a/internal/pkg/db/models/grocery_trip.go
+++ b/internal/pkg/db/models/grocery_trip.go
@@ -35,7 +35,7 @@ func (g *GroceryTrip) AfterUpdate(tx *gorm.DB) (err error) {
 		// The new trip name is suffixed by a number that represents the number
 		// of trips the user has made to the store (i.e. "Trip 12")
 		newTripName := fmt.Sprintf("Trip %d", (tripsCount + 1))
-		newTrip := GroceryTrip{StoreID: g.StoreID, Name: newTripName}
+		newTrip := &GroceryTrip{StoreID: g.StoreID, Name: newTripName}
 		if err := tx.Create(&newTrip).Error; err != nil {
 			return err
 		}
@@ -43,18 +43,51 @@ func (g *GroceryTrip) AfterUpdate(tx *gorm.DB) (err error) {
 		// If the completed trip was configured to copy its remaining items
 		// over to the next trip, perform this operation - otherwise, mark
 		// each item in the completed trip as completed
-		completed := true
-		columns := Item{Completed: &completed}
 		if g.CopyRemainingItems {
-			columns = Item{GroceryTripID: newTrip.ID}
-		}
-		updateItemsQuery := tx.
-			Model(&Item{}).
-			Where("grocery_trip_id = ? AND completed = ?", g.ID, false).
-			UpdateColumns(columns).
-			Error
-		if err := updateItemsQuery; err != nil {
-			return err
+			// Duplicate the catgeory associated with each item
+			remainingItems := []Item{}
+			if err := tx.Where("grocery_trip_id = ? AND completed = ?", g.ID, false).Find(&remainingItems).Error; err != nil {
+				return err
+			}
+			for i := range remainingItems {
+				// Retrieve the store category associated with the previous trip and use it
+				// to create a duplicate grocery trip category in new trip
+				// (note: use FindOrCreate to handle multiple items in same category)
+				storeCategory := &StoreCategory{}
+				storeCategoryQuery := tx.
+					Select("store_categories.id, store_categories.name").
+					Joins("INNER JOIN grocery_trip_categories ON grocery_trip_categories.store_category_id = store_categories.id").
+					Where("grocery_trip_categories.id = ?", remainingItems[i].CategoryID).
+					Find(&storeCategory).
+					Error
+				if err := storeCategoryQuery; err != nil {
+					return err
+				}
+				// Note: uses FirstOrCreate to handle the case where there are multiple items in same category
+				// that need to be moved over to the next trip
+				groceryTripCategory := GroceryTripCategory{GroceryTripID: newTrip.ID, StoreCategoryID: storeCategory.ID}
+				if err := tx.Where(groceryTripCategory).FirstOrCreate(&groceryTripCategory).Error; err != nil {
+					return err
+				}
+				updateItemsQuery := tx.
+					Model(&Item{}).
+					Where("grocery_trip_id = ? AND completed = ?", g.ID, false).
+					UpdateColumns(Item{GroceryTripID: newTrip.ID, CategoryID: &groceryTripCategory.ID}).
+					Error
+				if err := updateItemsQuery; err != nil {
+					return err
+				}
+			}
+		} else {
+			completed := true
+			updateItemsQuery := tx.
+				Model(&Item{}).
+				Where("grocery_trip_id = ? AND completed = ?", g.ID, false).
+				UpdateColumns(Item{Completed: &completed}).
+				Error
+			if err := updateItemsQuery; err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/pkg/trips/update_trip.go
+++ b/internal/pkg/trips/update_trip.go
@@ -1,6 +1,8 @@
 package trips
 
 import (
+	"errors"
+
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
 )
@@ -9,7 +11,7 @@ import (
 func UpdateTrip(args map[string]interface{}) (interface{}, error) {
 	trip := models.GroceryTrip{}
 	if err := db.Manager.Where("id = ?", args["tripId"]).First(&trip).Error; err != nil {
-		return nil, err
+		return nil, errors.New("trip does not exist")
 	}
 	if args["name"] != nil {
 		trip.Name = args["name"].(string)


### PR DESCRIPTION
When I added store categories/grocery trip categories, I broke the "Copy remaining items over" setting on the trip summary when completing a trip. We also needed to factor in moving over the categories associated with the remaining items, so this took some refactoring. 