### PR TITLE
Update trip names to be date based

### DIFF
--- a/internal/pkg/db/models/grocery_trip.go
+++ b/internal/pkg/db/models/grocery_trip.go
@@ -88,12 +88,12 @@ func (g *GroceryTrip) AfterUpdate(tx *gorm.DB) (err error) {
 // BeforeCreate hook is triggered before a trip is created
 func (g *GroceryTrip) BeforeCreate(tx *gorm.DB) (err error) {
 	// If this store has already had a trip with this name, affix a count to it to make it unique
-	var dupeCount int64
-	if err := tx.Model(&GroceryTrip{}).Where("name = ? AND store_id = ?", g.Name, g.StoreID).Count(&dupeCount).Error; err != nil {
+	var count int64
+	if err := tx.Model(&GroceryTrip{}).Where("name = ? AND store_id = ?", g.Name, g.StoreID).Count(&count).Error; err != nil {
 		return err
 	}
-	if dupeCount > 0 {
-		g.Name = fmt.Sprintf("%s (%d)", g.Name, (dupeCount + 1))
+	if count > 0 {
+		g.Name = fmt.Sprintf("%s (%d)", g.Name, (count + 1))
 	}
 	return
 }

--- a/internal/pkg/db/models/grocery_trip.go
+++ b/internal/pkg/db/models/grocery_trip.go
@@ -33,7 +33,7 @@ func (g *GroceryTrip) AfterUpdate(tx *gorm.DB) (err error) {
 
 		// Create the next trip for the user
 		currentTime := time.Now()
-		newTripName := currentTime.Format("January 02, 2006")
+		newTripName := currentTime.Format("Jan 02, 2006")
 		newTrip := &GroceryTrip{StoreID: g.StoreID, Name: newTripName}
 		if err := tx.Create(&newTrip).Error; err != nil {
 			return err
@@ -92,6 +92,8 @@ func (g *GroceryTrip) BeforeCreate(tx *gorm.DB) (err error) {
 	if err := tx.Model(&GroceryTrip{}).Where("name = ? AND store_id = ?", g.Name, g.StoreID).Count(&dupeCount).Error; err != nil {
 		return err
 	}
-	g.Name = fmt.Sprintf("%s (%d)", g.Name, (dupeCount + 1))
+	if dupeCount > 0 {
+		g.Name = fmt.Sprintf("%s (%d)", g.Name, (dupeCount + 1))
+	}
 	return
 }

--- a/internal/pkg/db/models/store.go
+++ b/internal/pkg/db/models/store.go
@@ -45,9 +45,11 @@ func (s *Store) AfterCreate(tx *gorm.DB) (err error) {
 	}
 
 	// Create default grocery trip
+	currentTime := time.Now()
+	tripName := currentTime.Format("Jan 02, 2006")
 	trip := GroceryTrip{
 		StoreID:            s.ID,
-		Name:               "Trip 1",
+		Name:               tripName,
 		Completed:          false,
 		CopyRemainingItems: false,
 	}

--- a/internal/pkg/stores/create_test.go
+++ b/internal/pkg/stores/create_test.go
@@ -1,6 +1,8 @@
 package stores
 
 import (
+	"time"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
@@ -42,8 +44,13 @@ func (s *Suite) TestCreateStore_Created() {
 			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
 	}
 
+	currentTime := time.Now()
+	tripName := currentTime.Format("Jan 02, 2006")
+	s.mock.ExpectQuery("^SELECT count*").
+		WithArgs(tripName, sqlmock.AnyArg()).
+		WillReturnRows(s.mock.NewRows([]string{"count"}).AddRow(0))
 	s.mock.ExpectQuery("^INSERT INTO \"grocery_trips\" (.+)$").
-		WithArgs(sqlmock.AnyArg(), "Trip 1", false, false, AnyTime{}, AnyTime{}, nil).
+		WithArgs(sqlmock.AnyArg(), tripName, false, false, AnyTime{}, AnyTime{}, nil).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
 	s.mock.ExpectCommit()
 


### PR DESCRIPTION
This has gone through a few iterations. First the app required you to provide a trip name, which I changed my mind about because it just doesn't seem necessary or realistic to expect.. (nor do trips necessarily always have a name like "Trip to the cottage!"). Then I tried making them sequential, i.e. "Trip 1...Trip 2...Trip 3", but that didn't seem right either.

I think trip names have to be date based, i.e. "Sept 21, 2020". We even handle multiple trips in the same day by affixing a count at the end of the trip name, i.e. "Sept 21, 2020 (2)" etc.

Let's try this.