### PR TITLE
Fix copy items operation not attributing categories properly

### DIFF
--- a/internal/pkg/db/models/grocery_trip.go
+++ b/internal/pkg/db/models/grocery_trip.go
@@ -26,12 +26,11 @@ type GroceryTrip struct {
 // AfterUpdate hook is triggered after a trip is updated, such as in trips.UpdateTrip
 func (g *GroceryTrip) AfterUpdate(tx *gorm.DB) (err error) {
 	if g.Completed {
+		// Create the next trip for the user
 		var tripsCount int64
 		if err := tx.Model(&GroceryTrip{}).Where("store_id = ?", g.StoreID).Count(&tripsCount).Error; err != nil {
 			return err
 		}
-
-		// Create the next trip for the user
 		currentTime := time.Now()
 		newTripName := currentTime.Format("Jan 02, 2006")
 		newTrip := &GroceryTrip{StoreID: g.StoreID, Name: newTripName}
@@ -39,21 +38,21 @@ func (g *GroceryTrip) AfterUpdate(tx *gorm.DB) (err error) {
 			return err
 		}
 
-		// If the completed trip was configured to copy its remaining items
-		// over to the next trip, perform this operation - otherwise, mark
-		// each item in the completed trip as completed
-		completed := true
-		columns := Item{Completed: &completed}
+		// Handle copy operation the completed trip was configured to copy its
+		// remaining items over to the next trip
+
 		if g.CopyRemainingItems {
 			// Duplicate the category associated with each item
 			var remainingItems []Item
 			if err := tx.Where("grocery_trip_id = ? AND completed = ?", g.ID, false).Find(&remainingItems).Error; err != nil {
 				return err
 			}
+
+			var newItems []Item
 			for i := range remainingItems {
 				// Retrieve the store category associated with the previous trip and use it
 				// to create a duplicate grocery trip category in new trip
-				// (note: use FindOrCreate to handle multiple items in same category)
+				// (note: use FindOrCreate to avoid dupe categories)
 				storeCategory := &StoreCategory{}
 				storeCategoryQuery := tx.
 					Select("store_categories.id, store_categories.name").
@@ -70,13 +69,29 @@ func (g *GroceryTrip) AfterUpdate(tx *gorm.DB) (err error) {
 				if err := tx.Where(groceryTripCategory).FirstOrCreate(&groceryTripCategory).Error; err != nil {
 					return err
 				}
-				columns = Item{GroceryTripID: newTrip.ID, CategoryID: &groceryTripCategory.ID}
+
+				// Copy old item to new item and update values
+				newItem := remainingItems[i]
+				newItem.ID = uuid.Nil
+				newItem.GroceryTripID = newTrip.ID
+				newItem.CategoryID = &groceryTripCategory.ID
+				newItems = append(newItems, newItem)
+			}
+
+			// Batch insert items in new trip
+			if err := tx.Create(&newItems).Error; err != nil {
+				return err
 			}
 		}
+
+		// Mark each item in the old trip as completed
+		//
+		// This uses UpdateColumn to avoid hooks
+		// (https://gorm.io/docs/update.html#Without-Hooks-Time-Tracking)
 		updateItemsQuery := tx.
 			Model(&Item{}).
 			Where("grocery_trip_id = ? AND completed = ?", g.ID, false).
-			UpdateColumns(columns).
+			UpdateColumn("completed", true).
 			Error
 		if err := updateItemsQuery; err != nil {
 			return err
@@ -89,11 +104,12 @@ func (g *GroceryTrip) AfterUpdate(tx *gorm.DB) (err error) {
 func (g *GroceryTrip) BeforeCreate(tx *gorm.DB) (err error) {
 	// If this store has already had a trip with this name, affix a count to it to make it unique
 	var count int64
-	if err := tx.Model(&GroceryTrip{}).Where("name = ? AND store_id = ?", g.Name, g.StoreID).Count(&count).Error; err != nil {
+	name := fmt.Sprintf("%%%s%%", g.Name) // LIKE '%Oct 08, 2020%'
+	if err := tx.Model(&GroceryTrip{}).Where("name LIKE ? AND store_id = ?", name, g.StoreID).Count(&count).Error; err != nil {
 		return err
 	}
 	if count > 0 {
-		g.Name = fmt.Sprintf("%s (%d)", g.Name, count + 1)
+		g.Name = fmt.Sprintf("%s (%d)", g.Name, count+1)
 	}
 	return
 }

--- a/internal/pkg/stores/create_test.go
+++ b/internal/pkg/stores/create_test.go
@@ -1,6 +1,7 @@
 package stores
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -46,8 +47,9 @@ func (s *Suite) TestCreateStore_Created() {
 
 	currentTime := time.Now()
 	tripName := currentTime.Format("Jan 02, 2006")
+	likeTripName := fmt.Sprintf("%%%s%%", tripName)
 	s.mock.ExpectQuery("^SELECT count*").
-		WithArgs(tripName, sqlmock.AnyArg()).
+		WithArgs(likeTripName, sqlmock.AnyArg()).
 		WillReturnRows(s.mock.NewRows([]string{"count"}).AddRow(0))
 	s.mock.ExpectQuery("^INSERT INTO \"grocery_trips\" (.+)$").
 		WithArgs(sqlmock.AnyArg(), tripName, false, false, AnyTime{}, AnyTime{}, nil).

--- a/internal/pkg/trips/add_items_to_store.go
+++ b/internal/pkg/trips/add_items_to_store.go
@@ -59,11 +59,14 @@ func FindOrCreateStore(userID uuid.UUID, name string) (storeRecord models.Store,
 }
 
 // FindCurrentTripIDInStore retrieves the ID of the most recent trip in the store that hasn't been completed
+//
+// TODO: DRY this up with trips.RetrieveCurrentStoreTrip
 func FindCurrentTripIDInStore(storeID uuid.UUID) (tripID uuid.UUID, err error) {
 	trip := models.GroceryTrip{}
 	tripQuery := db.Manager.
 		Select("id").
 		Where("store_id = ? AND completed = ?", storeID, false).
+		Order("created_at DESC").
 		Last(&trip).
 		Error
 	if err := tripQuery; err != nil {

--- a/internal/pkg/trips/add_items_to_store_test.go
+++ b/internal/pkg/trips/add_items_to_store_test.go
@@ -1,6 +1,7 @@
 package trips
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -75,8 +76,9 @@ func (s *Suite) TestFindOrCreateStore_StoreCreated() {
 
 	currentTime := time.Now()
 	tripName := currentTime.Format("Jan 02, 2006")
+	likeTripName := fmt.Sprintf("%%%s%%", tripName)
 	s.mock.ExpectQuery("^SELECT count*").
-		WithArgs(tripName, sqlmock.AnyArg()).
+		WithArgs(likeTripName, sqlmock.AnyArg()).
 		WillReturnRows(s.mock.NewRows([]string{"count"}).AddRow(0))
 	s.mock.ExpectQuery("^INSERT INTO \"grocery_trips\" (.+)$").
 		WithArgs(sqlmock.AnyArg(), tripName, false, false, AnyTime{}, AnyTime{}, nil).

--- a/internal/pkg/trips/update_trip_test.go
+++ b/internal/pkg/trips/update_trip_test.go
@@ -70,8 +70,9 @@ func (s *Suite) TestUpdateTrip_DupeTripName() {
 	// Note: this covers the case where a user creates multiple trips in the same day
 	currentTime := time.Now()
 	tripName := currentTime.Format("Jan 02, 2006")
+	likeTripName := fmt.Sprintf("%%%s%%", tripName)
 	s.mock.ExpectQuery("^SELECT count*").
-		WithArgs(tripName, storeID).
+		WithArgs(likeTripName, storeID).
 		WillReturnRows(s.mock.NewRows([]string{"count"}).AddRow(1))
 	finalTripName := fmt.Sprintf("%s (%d)", tripName, 2)
 	s.mock.ExpectQuery("^INSERT INTO \"grocery_trips\" (.+)$").
@@ -112,8 +113,9 @@ func (s *Suite) TestUpdateTrip_MarkCompleted() {
 
 	currentTime := time.Now()
 	tripName := currentTime.Format("Jan 02, 2006")
+	likeTripName := fmt.Sprintf("%%%s%%", tripName)
 	s.mock.ExpectQuery("^SELECT count*").
-		WithArgs(tripName, storeID).
+		WithArgs(likeTripName, storeID).
 		WillReturnRows(s.mock.NewRows([]string{"count"}).AddRow(0))
 	s.mock.ExpectQuery("^INSERT INTO \"grocery_trips\" (.+)$").
 		WithArgs(storeID, tripName, false, false, AnyTime{}, AnyTime{}, nil).
@@ -147,8 +149,9 @@ func (s *Suite) TestUpdateTrip_MarkCompletedAndCopyRemainingItems() {
 	newTripID := uuid.NewV4()
 	currentTime := time.Now()
 	tripName := currentTime.Format("Jan 02, 2006")
+	likeTripName := fmt.Sprintf("%%%s%%", tripName)
 	s.mock.ExpectQuery("^SELECT count*").
-		WithArgs(tripName, storeID).
+		WithArgs(likeTripName, storeID).
 		WillReturnRows(s.mock.NewRows([]string{"count"}).AddRow(0))
 	s.mock.ExpectQuery("^INSERT INTO \"grocery_trips\" (.+)$").
 		WithArgs(storeID, tripName, false, false, AnyTime{}, AnyTime{}, nil).
@@ -166,6 +169,9 @@ func (s *Suite) TestUpdateTrip_MarkCompletedAndCopyRemainingItems() {
 		WillReturnRows(s.mock.NewRows([]string{"id", "name"}).AddRow(storeCategoryID, "Produce"))
 	s.mock.ExpectQuery("^SELECT (.+) FROM \"grocery_trip_categories\"*").
 		WithArgs(newTripID, storeCategoryID).
+		WillReturnRows(s.mock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
+	s.mock.ExpectQuery("^INSERT INTO \"items\" (.+)$").
+		WithArgs(newTripID, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), 1, false, 1, AnyTime{}, AnyTime{}, nil).
 		WillReturnRows(s.mock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
 	s.mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))


### PR DESCRIPTION
Now we literally copy items instead of updating the items from the last trip. We will need to do this for trip history anyway.

Also fixed:

- Issue with naming multiple trips in the same day. Previously it would max out at e.g. `Oct 08, 2020 (2)`

- Fix issue where adding items via Siri could get the current trip incorrectly. Still some cleanup/DRYing up to do yet, but didn't want to go too far in this PR