### PR TITLE
simplify token field on UserType

### DIFF
--- a/internal/pkg/gql/types/user.go
+++ b/internal/pkg/gql/types/user.go
@@ -75,9 +75,9 @@ var UserType = graphql.NewObject(
 					return authToken.AccessToken, nil
 				},
 			},
+			// DEPRECATED in favour of accessToken
 			"token": &graphql.Field{
-				Type:        AuthTokenType,
-				Description: "DEPRECATED in favour of accessToken",
+				Type: AuthTokenType,
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					userID := p.Source.(*models.User).ID
 					authToken := &models.AuthToken{}

--- a/internal/pkg/gql/types/user.go
+++ b/internal/pkg/gql/types/user.go
@@ -60,14 +60,19 @@ var UserType = graphql.NewObject(
 				},
 			},
 			"token": &graphql.Field{
-				Type: AuthTokenType,
+				Type: graphql.String,
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					userID := p.Source.(*models.User).ID
-					authToken := &models.AuthToken{}
-					if err := db.Manager.Where("user_id = ?", userID).Last(&authToken).Error; err != nil {
+					var authToken models.AuthToken
+					query := db.Manager.
+						Select("access_token").
+						Where("user_id = ?", userID).
+						Last(&authToken).
+						Error
+					if err := query; err != nil {
 						return nil, errors.New("token not found for user")
 					}
-					return authToken, nil
+					return authToken.AccessToken, nil
 				},
 			},
 		},

--- a/internal/pkg/gql/types/user.go
+++ b/internal/pkg/gql/types/user.go
@@ -59,7 +59,7 @@ var UserType = graphql.NewObject(
 					return nil, nil
 				},
 			},
-			"token": &graphql.Field{
+			"accessToken": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					userID := p.Source.(*models.User).ID
@@ -73,6 +73,18 @@ var UserType = graphql.NewObject(
 						return nil, errors.New("token not found for user")
 					}
 					return authToken.AccessToken, nil
+				},
+			},
+			"token": &graphql.Field{
+				Type:        AuthTokenType,
+				Description: "DEPRECATED in favour of accessToken",
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					userID := p.Source.(*models.User).ID
+					authToken := &models.AuthToken{}
+					if err := db.Manager.Where("user_id = ?", userID).Last(&authToken).Error; err != nil {
+						return nil, errors.New("token not found for user")
+					}
+					return authToken, nil
 				},
 			},
 		},


### PR DESCRIPTION
Just returns the token as a string instead of `AuthTokenType`. With this I can likely also remove that type altogether, need to check though.

**Note:** This change will be included in 2020.3, and then this will need to be deployed.