### PR TITLE
Allow two simultaneous auth tokens

### DIFF
--- a/internal/pkg/db/models/auth_token.go
+++ b/internal/pkg/db/models/auth_token.go
@@ -11,6 +11,10 @@ import (
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/utils"
 )
 
+// AuthTokensOffset is the number of tokens we retain when cleaning up
+const AuthTokensOffset = 2
+
+// AuthToken is a model that represents the auth_tokens table
 type AuthToken struct {
 	ID           uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
 	ClientID     uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();not null"`
@@ -26,12 +30,37 @@ type AuthToken struct {
 	User   User
 }
 
-// BeforeCreate generates the AccessToken and RefreshToken, and sets
-// ExpiresIn to 10 minutes from creation time so that access tokens frequently expire
+// BeforeCreate handles generating tokens and also handles old token cleanup
 func (c *AuthToken) BeforeCreate(tx *gorm.DB) (err error) {
+	// Generate the AccessToken and RefreshToken, and sets
+	// ExpiresIn to 10 minutes from creation time so that access tokens
+	// frequently expire.
+	//
+	// Note: refresh tokens are not currently in use
 	rand.Seed(time.Now().UnixNano())
 	c.AccessToken = utils.RandString(20)
 	c.RefreshToken = utils.RandString(20)
 	c.ExpiresIn = time.Now().Add(time.Minute * 10)
+
+	// Clean up old tokens after creation.
+	// Since our app is universal, it means a session can be held on both
+	// iOS and iPadOS simultaneously.
+	//
+	// Therefore, we only cleanup tokens if more than 2 exist.
+	subquery := tx.
+		Select("id").
+		Table("auth_tokens").
+		Where("user_id = ? AND client_id = ?", c.UserID, c.ClientID).
+		Order("created_at DESC").
+		Limit(100).
+		Offset(AuthTokensOffset)
+	tokenQuery := tx.
+		Where("id IN (?)", subquery).
+		Delete(&AuthToken{UserID: c.UserID, ClientID: c.ClientID}).
+		Error
+	if err := tokenQuery; err != nil {
+		return err
+	}
+
 	return
 }

--- a/internal/pkg/gql/resolvers/login.go
+++ b/internal/pkg/gql/resolvers/login.go
@@ -43,9 +43,6 @@ func LoginResolver(p graphql.ResolveParams) (interface{}, error) {
 	}
 
 	authToken := &models.AuthToken{UserID: user.ID, ClientID: apiClient.ID}
-	if err := db.Manager.Where("user_id = ? AND client_id = ?", user.ID, apiClient.ID).Delete(&authToken).Error; err != nil {
-		return nil, errors.New(wrongCredsMsg)
-	}
 	if err := db.Manager.Create(&authToken).Error; err != nil {
 		return nil, errors.New(wrongCredsMsg)
 	}

--- a/internal/pkg/gql/types/user.go
+++ b/internal/pkg/gql/types/user.go
@@ -67,6 +67,7 @@ var UserType = graphql.NewObject(
 					query := db.Manager.
 						Select("access_token").
 						Where("user_id = ?", userID).
+						Order("created_at DESC").
 						Last(&authToken).
 						Error
 					if err := query; err != nil {
@@ -81,7 +82,12 @@ var UserType = graphql.NewObject(
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					userID := p.Source.(*models.User).ID
 					authToken := &models.AuthToken{}
-					if err := db.Manager.Where("user_id = ?", userID).Last(&authToken).Error; err != nil {
+					query := db.Manager.
+						Where("user_id = ?", userID).
+						Order("created_at DESC").
+						Last(&authToken).
+						Error
+					if err := query; err != nil {
 						return nil, errors.New("token not found for user")
 					}
 					return authToken, nil

--- a/internal/pkg/user/create_user_test.go
+++ b/internal/pkg/user/create_user_test.go
@@ -35,6 +35,9 @@ func (s *Suite) TestCreateUser_UserCreated() {
 		WithArgs(email, sqlmock.AnyArg(), name, nil, nil, AnyTime{}, AnyTime{}, AnyTime{}).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(userID))
 
+	s.mock.ExpectExec("^DELETE FROM \"auth_tokens\"*").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
 	clientID := uuid.NewV4()
 	s.mock.ExpectQuery("^INSERT INTO \"auth_tokens\" (.+)$").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), AnyTime{}, AnyTime{}, AnyTime{}, sqlmock.AnyArg(), sqlmock.AnyArg()).


### PR DESCRIPTION
Users should be able to be logged in on two devices at once, since we have an iOS and iPadOS version. Currently this is not possible because we dispose of a previous token as soon as a new one is created upon login, but we should only dispose old tokens if there are more than 2.