### PR TITLE
Allow one user auth token per device

### DIFF
--- a/internal/pkg/db/migration/main.go
+++ b/internal/pkg/db/migration/main.go
@@ -204,6 +204,18 @@ func AutoMigrateService(db *gorm.DB) error {
 				return tx.Exec("DELETE FROM store_user_preferences").Error
 			},
 		},
+		{
+			ID: "202011260730_add_device_name_to_auth_tokens",
+			Migrate: func(tx *gorm.DB) error {
+				type AuthToken struct {
+					DeviceName string `gorm:"type:varchar(100)"`
+				}
+				return tx.AutoMigrate(&AuthToken{})
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec("ALTER TABLE auth_tokens DROP COLUMN device_name").Error
+			},
+		},
 	})
 	return m.Migrate()
 }

--- a/internal/pkg/db/models/auth_token.go
+++ b/internal/pkg/db/models/auth_token.go
@@ -18,6 +18,7 @@ type AuthToken struct {
 	AccessToken  string    `gorm:"type:varchar(100);not null"`
 	RefreshToken string    `gorm:"type:varchar(100);not null"`
 	ExpiresIn    time.Time `gorm:"not null"`
+	DeviceName   string    `gorm:"type:varchar(100)"`
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 
@@ -26,12 +27,30 @@ type AuthToken struct {
 	User   User
 }
 
-// BeforeCreate generates the AccessToken and RefreshToken, and sets
-// ExpiresIn to 10 minutes from creation time so that access tokens frequently expire
+// BeforeCreate handles generating tokens and also handles old token cleanup
 func (c *AuthToken) BeforeCreate(tx *gorm.DB) (err error) {
+	// Generate the AccessToken and RefreshToken, and set
+	// ExpiresIn to 10 minutes from creation time so that access tokens
+	// frequently expire.
+	//
+	// Note: refresh tokens are not currently in use. deprecate?
 	rand.Seed(time.Now().UnixNano())
 	c.AccessToken = utils.RandString(20)
 	c.RefreshToken = utils.RandString(20)
 	c.ExpiresIn = time.Now().Add(time.Minute * 10)
+
+	// Clean up tokens after creation.
+	//
+	// Since our app is universal, it means a session can be held on both
+	// iOS and iPadOS simultaneously. Therefore, we only delete a token if it's
+	// replacing an existing token on the same device.
+	authToken := &AuthToken{}
+	tokenQuery := tx.
+		Where("user_id = ? AND client_id = ? AND device_name = ?", c.UserID, c.ClientID, c.DeviceName).
+		Delete(&authToken).
+		Error
+	if err := tokenQuery; err != nil {
+		return err
+	}
 	return
 }

--- a/internal/pkg/gql/main.go
+++ b/internal/pkg/gql/main.go
@@ -133,6 +133,9 @@ func init() {
 						"name": &graphql.ArgumentConfig{
 							Type: graphql.NewNonNull(graphql.String),
 						},
+						"deviceName": &graphql.ArgumentConfig{
+							Type: graphql.String,
+						},
 					},
 					Resolve: resolvers.SignupResolver,
 				},

--- a/internal/pkg/gql/main.go
+++ b/internal/pkg/gql/main.go
@@ -114,6 +114,9 @@ func init() {
 						"password": &graphql.ArgumentConfig{
 							Type: graphql.String,
 						},
+						"deviceName": &graphql.ArgumentConfig{
+							Type: graphql.String,
+						},
 					},
 					Resolve: resolvers.LoginResolver,
 				},

--- a/internal/pkg/gql/resolvers/login.go
+++ b/internal/pkg/gql/resolvers/login.go
@@ -42,9 +42,14 @@ func LoginResolver(p graphql.ResolveParams) (interface{}, error) {
 		return nil, errors.New(wrongCredsMsg)
 	}
 
-	authToken := &models.AuthToken{UserID: user.ID, ClientID: apiClient.ID}
-	if err := db.Manager.Where("user_id = ? AND client_id = ?", user.ID, apiClient.ID).Delete(&authToken).Error; err != nil {
-		return nil, errors.New(wrongCredsMsg)
+	var deviceName string
+	if p.Args["deviceName"] != nil {
+		deviceName = p.Args["deviceName"].(string)
+	}
+	authToken := &models.AuthToken{
+		UserID:     user.ID,
+		ClientID:   apiClient.ID,
+		DeviceName: deviceName,
 	}
 	if err := db.Manager.Create(&authToken).Error; err != nil {
 		return nil, errors.New(wrongCredsMsg)

--- a/internal/pkg/gql/resolvers/signup.go
+++ b/internal/pkg/gql/resolvers/signup.go
@@ -26,7 +26,11 @@ func SignupResolver(p graphql.ResolveParams) (interface{}, error) {
 	email := p.Args["email"].(string)
 	password := p.Args["password"].(string)
 	name := p.Args["name"].(string)
-	user, err := user.CreateUser(email, password, name, apiClient.ID)
+	var deviceName string
+	if p.Args["deviceName"] != nil {
+		deviceName = p.Args["deviceName"].(string)
+	}
+	user, err := user.CreateUser(email, password, name, deviceName, apiClient.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/types/user.go
+++ b/internal/pkg/gql/types/user.go
@@ -67,6 +67,7 @@ var UserType = graphql.NewObject(
 					query := db.Manager.
 						Select("access_token").
 						Where("user_id = ?", userID).
+						Order("created_at DESC").
 						Last(&authToken).
 						Error
 					if err := query; err != nil {
@@ -81,7 +82,12 @@ var UserType = graphql.NewObject(
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					userID := p.Source.(*models.User).ID
 					authToken := &models.AuthToken{}
-					if err := db.Manager.Where("user_id = ?", userID).Last(&authToken).Error; err != nil {
+					query := db.Manager.
+						Where("user_id = ?", userID).
+						Order("created_at DESC").
+						Last(&authToken).
+						Error
+					if err := query; err != nil {
 						return nil, errors.New("token not found for user")
 					}
 					return authToken, nil

--- a/internal/pkg/user/create_user.go
+++ b/internal/pkg/user/create_user.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CreateUser creates a user account with details provided
-func CreateUser(email string, password string, name string, clientID uuid.UUID) (*models.User, error) {
+func CreateUser(email string, password string, name string, deviceName string, clientID uuid.UUID) (*models.User, error) {
 	passhash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func CreateUser(email string, password string, name string, clientID uuid.UUID) 
 		Email:      email,
 		Password:   string(passhash),
 		LastSeenAt: time.Now(),
-		Tokens:     []models.AuthToken{{ClientID: clientID}},
+		Tokens:     []models.AuthToken{{ClientID: clientID, DeviceName: deviceName}},
 	}
 	if err := db.Manager.Create(&user).Error; err != nil {
 		return nil, err

--- a/internal/pkg/user/create_user_test.go
+++ b/internal/pkg/user/create_user_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *Suite) TestCreateUser_InvalidPassword() {
-	_, e := CreateUser("test@example.com", "", "John", uuid.NewV4())
+	_, e := CreateUser("test@example.com", "", "John", "iPhone", uuid.NewV4())
 	require.Error(s.T(), e)
 }
 
@@ -18,7 +18,7 @@ func (s *Suite) TestCreateUser_DuplicateEmail() {
 		WithArgs(email).
 		WillReturnRows(sqlmock.NewRows([]string{"count(1)"}).AddRow(1))
 
-	_, e := CreateUser(email, "password", "John", uuid.NewV4())
+	_, e := CreateUser(email, "password", "John", "iPhone", uuid.NewV4())
 	require.Error(s.T(), e)
 	assert.Equal(s.T(), e.Error(), "An account with this email address already exists")
 }
@@ -35,12 +35,16 @@ func (s *Suite) TestCreateUser_UserCreated() {
 		WithArgs(email, sqlmock.AnyArg(), name, nil, nil, AnyTime{}, AnyTime{}, AnyTime{}).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(userID))
 
+	s.mock.ExpectExec("^DELETE FROM \"auth_tokens\"*").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	deviceName := "iGlasses"
 	clientID := uuid.NewV4()
 	s.mock.ExpectQuery("^INSERT INTO \"auth_tokens\" (.+)$").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), AnyTime{}, AnyTime{}, AnyTime{}, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), AnyTime{}, sqlmock.AnyArg(), AnyTime{}, AnyTime{}, sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "client_id", "user_id"}).AddRow(uuid.NewV4(), clientID, userID))
 
-	user, err := CreateUser(email, "password", name, clientID)
+	user, err := CreateUser(email, "password", name, deviceName, clientID)
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), user.Email, email)
 	assert.Equal(s.T(), user.Name, name)


### PR DESCRIPTION
In #30 I made it so that users could have two simultaneous auth tokens at once, but I thought on this a bit more and wasn't happy with the solution. 

This PR will allow an auth token per device. This is better because A) I don't need to update this if I build a Mac app or a web app etc. and B) the code is a lot cleaner and less complicated