### PR TITLE
Refactor and DRY up some commonly used code to retrieve the current trip for a store

### DIFF
--- a/internal/pkg/gql/types/store.go
+++ b/internal/pkg/gql/types/store.go
@@ -37,7 +37,7 @@ var StoreType = graphql.NewObject(
 					}
 
 					storeID := p.Source.(models.Store).ID
-					trip, err := trips.RetrieveCurrentStoreTrip(storeID, user.(models.User))
+					trip, err := trips.RetrieveCurrentStoreTripForUser(storeID, user.(models.User))
 					if err != nil {
 						return nil, err
 					}

--- a/internal/pkg/trips/add_items_to_store.go
+++ b/internal/pkg/trips/add_items_to_store.go
@@ -31,7 +31,7 @@ func AddItemsToStore(userID uuid.UUID, args map[string]interface{}) (addedItems 
 	}
 
 	// Fetch the current trip for this store
-	tripID, err := FindCurrentTripIDInStore(store.ID)
+	trip, err := RetrieveCurrentStoreTrip(store.ID)
 	if err != nil {
 		return addedItems, errors.New("could not find current trip in store")
 	}
@@ -41,7 +41,7 @@ func AddItemsToStore(userID uuid.UUID, args map[string]interface{}) (addedItems 
 	for i := range itemNames {
 		itemName := itemNames[i].(string)
 		item, err := AddItem(userID, map[string]interface{}{
-			"tripId":   tripID,
+			"tripId":   trip.ID,
 			"name":     itemName,
 			"quantity": 1,
 		})
@@ -75,23 +75,6 @@ func FindOrCreateStore(userID uuid.UUID, name string) (storeRecord models.Store,
 		return newStore, nil
 	}
 	return store, nil
-}
-
-// FindCurrentTripIDInStore retrieves the ID of the most recent trip in the store that hasn't been completed
-//
-// TODO: DRY this up with trips.RetrieveCurrentStoreTrip
-func FindCurrentTripIDInStore(storeID uuid.UUID) (tripID uuid.UUID, err error) {
-	trip := models.GroceryTrip{}
-	tripQuery := db.Manager.
-		Select("id").
-		Where("store_id = ? AND completed = ?", storeID, false).
-		Order("created_at DESC").
-		Last(&trip).
-		Error
-	if err := tripQuery; err != nil {
-		return tripID, err
-	}
-	return trip.ID, nil
 }
 
 // FindDefaultStore retrieves the ID of the store that is set as the default for the userID provided

--- a/internal/pkg/trips/add_items_to_store_test.go
+++ b/internal/pkg/trips/add_items_to_store_test.go
@@ -85,29 +85,6 @@ func (s *Suite) TestFindOrCreateStore_StoreCreated() {
 	assert.Equal(s.T(), store.Name, storeName)
 }
 
-func (s *Suite) TestFindCurrentTripIDInStore_NotFound() {
-	storeID := uuid.NewV4()
-	s.mock.ExpectQuery("^SELECT (.+) FROM \"grocery_trips\"*").
-		WithArgs(storeID, false).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}))
-
-	_, err := FindCurrentTripIDInStore(storeID)
-	require.Error(s.T(), err)
-	assert.Equal(s.T(), err.Error(), "record not found")
-}
-
-func (s *Suite) TestFindCurrentTripIDInStore_Found() {
-	storeID := uuid.NewV4()
-	tripID := uuid.NewV4()
-	s.mock.ExpectQuery("^SELECT (.+) FROM \"grocery_trips\"*").
-		WithArgs(storeID, false).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(tripID))
-
-	currentTripID, err := FindCurrentTripIDInStore(storeID)
-	require.NoError(s.T(), err)
-	assert.Equal(s.T(), currentTripID, tripID)
-}
-
 // TODO: duplicated code with the store model... DRY this up
 func fetchCategories() [20]string {
 	categories := [20]string{

--- a/internal/pkg/trips/trips.go
+++ b/internal/pkg/trips/trips.go
@@ -30,7 +30,7 @@ func RetrieveCurrentStoreTripForUser(storeID uuid.UUID, user models.User) (groce
 
 // RetrieveCurrentStoreTrip retrieves the currently active grocery trip in a store
 func RetrieveCurrentStoreTrip(storeID uuid.UUID) (groceryTrip models.GroceryTrip, err error) {
-	trip := models.GroceryTrip{}
+	var trip models.GroceryTrip
 	query := db.Manager.
 		Where("store_id = ? AND completed = ?", storeID, false).
 		Order("created_at DESC").

--- a/internal/pkg/trips/trips.go
+++ b/internal/pkg/trips/trips.go
@@ -30,16 +30,15 @@ func RetrieveCurrentStoreTripForUser(storeID uuid.UUID, user models.User) (groce
 
 // RetrieveCurrentStoreTrip retrieves the currently active grocery trip in a store
 func RetrieveCurrentStoreTrip(storeID uuid.UUID) (groceryTrip models.GroceryTrip, err error) {
-	var trip models.GroceryTrip
 	query := db.Manager.
 		Where("store_id = ? AND completed = ?", storeID, false).
 		Order("created_at DESC").
-		Last(&trip).
+		Last(&groceryTrip).
 		Error
 	if err := query; err != nil {
 		return groceryTrip, err
 	}
-	return trip, nil
+	return groceryTrip, nil
 }
 
 // RetrieveTrips retrieves grocery trips within a store

--- a/internal/pkg/trips/trips_test.go
+++ b/internal/pkg/trips/trips_test.go
@@ -50,27 +50,27 @@ func TestSuite(t *testing.T) {
 	suite.Run(t, new(Suite))
 }
 
-func (s *Suite) TestRetrieveCurrentStoreTrip_UserNotMemberOfStore() {
+func (s *Suite) TestRetrieveCurrentStoreTripForUser_UserNotMemberOfStore() {
 	storeID := uuid.NewV4()
 	user := models.User{ID: uuid.NewV4()}
-	_, err := RetrieveCurrentStoreTrip(storeID, user)
+	_, err := RetrieveCurrentStoreTripForUser(storeID, user)
 	require.Error(s.T(), err)
 	assert.Equal(s.T(), err.Error(), "user is not a member of this store")
 }
 
-func (s *Suite) TestRetrieveCurrentStoreTrip_TripNotAssociatedWithStore() {
+func (s *Suite) TestRetrieveCurrentStoreTripForUser_TripNotAssociatedWithStore() {
 	storeID := uuid.NewV4()
 	user := models.User{ID: uuid.NewV4(), Email: "test@example.com"}
 	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
 		WithArgs(storeID, user.ID, user.Email).
 		WillReturnRows(s.mock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
 
-	_, err := RetrieveCurrentStoreTrip(storeID, user)
+	_, err := RetrieveCurrentStoreTripForUser(storeID, user)
 	require.Error(s.T(), err)
 	assert.Equal(s.T(), err.Error(), "could not find trip associated with this store")
 }
 
-func (s *Suite) TestRetrieveCurrentStoreTrip_FoundResult() {
+func (s *Suite) TestRetrieveCurrentStoreTripForUser_FoundResult() {
 	storeID := uuid.NewV4()
 	user := models.User{ID: uuid.NewV4(), Email: "test@example.com"}
 	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_users\"*").
@@ -83,7 +83,7 @@ func (s *Suite) TestRetrieveCurrentStoreTrip_FoundResult() {
 		WithArgs(storeID, false).
 		WillReturnRows(s.mock.NewRows([]string{"id", "name"}).AddRow(tripID, tripName))
 
-	trip, err := RetrieveCurrentStoreTrip(storeID, user)
+	trip, err := RetrieveCurrentStoreTripForUser(storeID, user)
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), trip.Name, tripName)
 }


### PR DESCRIPTION
This eradicates the `FindCurrentTripIDInStore` function which was used in `AddItemsToStore`. With some small refactors we're able to get rid of that function and reuse a function in trips to fetch the current trip in the store.