### PR TITLE
Cleanup migrations, add missing indices to models

### DIFF
--- a/internal/pkg/db/migration/main.go
+++ b/internal/pkg/db/migration/main.go
@@ -3,10 +3,8 @@ package migration
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/go-gormigrate/gormigrate/v2"
-	uuid "github.com/satori/go.uuid"
 	"gorm.io/gorm"
 
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
@@ -52,13 +50,19 @@ func AutoMigrateService(db *gorm.DB) error {
 
 	m = gormigrate.New(db, gormigrate.DefaultOptions, []*gormigrate.Migration{
 		{
-			// Create default API client
+			// Create default clients
 			ID: "202003021034_default_api_client",
 			Migrate: func(tx *gorm.DB) error {
-				return tx.Create(&models.ApiClient{Name: "GroceryTime for iOS"}).Error
+				if err := tx.Create(&models.ApiClient{Name: "GroceryTime for iOS"}).Error; err != nil {
+					return err
+				}
+				if err := tx.Create(&models.ApiClient{Name: "GroceryTime for Web"}).Error; err != nil {
+					return err
+				}
+				return nil
 			},
 			Rollback: func(tx *gorm.DB) error {
-				return tx.Where("name = ?", "GroceryTime for iOS").Delete(&models.ApiClient{}).Error
+				return tx.Exec("TRUNCATE TABLE api_clients").Error
 			},
 		},
 		{
@@ -82,56 +86,6 @@ func AutoMigrateService(db *gorm.DB) error {
 			},
 		},
 		{
-			// Add index idx_store_users_user_id
-			ID: "202006021118_add_idx_store_users_store_id",
-			Migrate: func(tx *gorm.DB) error {
-				return tx.Exec("CREATE INDEX idx_store_users_store_id ON store_users (store_id)").Error
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Exec("DROP INDEX idx_store_users_store_id").Error
-			},
-		},
-		{
-			// Add index idx_store_categories_store_id
-			ID: "202009060829_add_idx_store_categories_store_id",
-			Migrate: func(tx *gorm.DB) error {
-				return tx.Exec("CREATE INDEX idx_store_categories_store_id ON store_categories (store_id)").Error
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Exec("DROP INDEX idx_store_categories_store_id").Error
-			},
-		},
-		{
-			// Add index idx_grocery_trips_store_id
-			ID: "202009060831_add_idx_grocery_trips_store_id",
-			Migrate: func(tx *gorm.DB) error {
-				return tx.Exec("CREATE INDEX idx_grocery_trips_store_id ON grocery_trips (store_id)").Error
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Exec("DROP INDEX idx_grocery_trips_store_id").Error
-			},
-		},
-		{
-			// Add index idx_grocery_trip_categories_grocery_trip_id
-			ID: "202009060833_add_idx_grocery_trip_categories_grocery_trip_id",
-			Migrate: func(tx *gorm.DB) error {
-				return tx.Exec("CREATE INDEX idx_grocery_trip_categories_grocery_trip_id ON grocery_trip_categories (grocery_trip_id)").Error
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Exec("DROP INDEX idx_grocery_trip_categories_grocery_trip_id").Error
-			},
-		},
-		{
-			// Add index idx_grocery_trip_categories_grocery_trip_id
-			ID: "202009060835_add_idx_grocery_trip_categories_store_category_id",
-			Migrate: func(tx *gorm.DB) error {
-				return tx.Exec("CREATE INDEX idx_grocery_trip_categories_store_category_id ON grocery_trip_categories (store_category_id)").Error
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Exec("DROP INDEX idx_grocery_trip_categories_store_category_id").Error
-			},
-		},
-		{
 			// Add index idx_items_grocery_trip_id_name
 			ID: "202010111143_add_idx_items_grocery_trip_id_name",
 			Migrate: func(tx *gorm.DB) error {
@@ -142,198 +96,16 @@ func AutoMigrateService(db *gorm.DB) error {
 			},
 		},
 		{
-			// Add password reset fields to user
-			ID: "202010310840_add_password_reset_token_and_password_reset_token_expiry_to_users",
+			// Add index for meals.date (string column)
+			ID: "202101091236_meals_date_index",
 			Migrate: func(tx *gorm.DB) error {
-				type User struct {
-					PasswordResetToken       uuid.UUID `gorm:"type:uuid"`
-					PasswordResetTokenExpiry time.Time
-				}
-				return tx.AutoMigrate(&User{})
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Exec("ALTER TABLE users DROP COLUMN password_reset_token, DROP COLUMN password_reset_token_expiry").Error
-			},
-		},
-		{
-			// Create web API client
-			ID: "202010310843_web_api_client",
-			Migrate: func(tx *gorm.DB) error {
-				return tx.Create(&models.ApiClient{Name: "GroceryTime for Web"}).Error
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Where("name = ?", "GroceryTime for Web").Delete(&models.ApiClient{}).Error
-			},
-		},
-		{
-			// Create schema for meal planning
-			ID: "202011112039_create_meal_planning_schema",
-			Migrate: func(tx *gorm.DB) error {
-				type Recipe struct {
-					ID       uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-					UserID   uuid.UUID `gorm:"type:uuid;not null;index:idx_recipes_user_id"`
-					Name     string    `gorm:"type:varchar(255);not null;index:idx_recipes_name"`
-					URL      *string   `gorm:"type:varchar(255)"`
-					MealType string    `gorm:"type:varchar(10);not null"`
-
-					CreatedAt time.Time
-					UpdatedAt time.Time
-					DeletedAt gorm.DeletedAt
-				}
-				tx.AutoMigrate(&Recipe{})
-
-				type RecipeIngredient struct {
-					ID       uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-					RecipeID uuid.UUID `gorm:"type:uuid;not null;index:idx_recipe_ingredients_recipe_id"`
-					Name     string    `gorm:"type:varchar(255);not null"`
-					Amount   *float64  `gorm:"default:1"`
-					Unit     *string   `gorm:"type:varchar(20)"`
-					Notes    *string   `gorm:"type:varchar(255);"`
-
-					CreatedAt time.Time
-					UpdatedAt time.Time
-					DeletedAt gorm.DeletedAt
-				}
-				tx.AutoMigrate(&RecipeIngredient{})
-
-				type MealUser struct {
-					ID     uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-					MealID uuid.UUID `gorm:"type:uuid;not null"`
-					UserID uuid.UUID `gorm:"type:uuid;not null"`
-
-					CreatedAt time.Time
-					UpdatedAt time.Time
-					DeletedAt gorm.DeletedAt
-				}
-				tx.AutoMigrate(&MealUser{})
-
-				type Meal struct {
-					ID       uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-					RecipeID uuid.UUID `gorm:"type:uuid;not null"`
-					UserID   uuid.UUID `gorm:"type:uuid;not null"`
-					Name     string    `gorm:"type:varchar(255);not null;index:idx_meals_name"`
-					MealType string    `gorm:"type:varchar(10);not null"`
-					Servings int       `gorm:"default:1;not null"`
-					Notes    *string   `gorm:"type:text"`
-					Date     string    `gorm:"type:varchar(255);not null"`
-
-					CreatedAt time.Time
-					UpdatedAt time.Time
-					DeletedAt gorm.DeletedAt
-				}
-				tx.AutoMigrate(&Meal{})
-
-				return nil
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Exec("DROP TABLE recipes, recipe_ingredients, meals, meal_users").Error
-			},
-		},
-		{
-			// Create store_user_preferences
-			ID: "202010071813_create_store_user_preferences",
-			Migrate: func(tx *gorm.DB) error {
-				type StoreUserPreference struct {
-					ID            uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-					StoreUserID   uuid.UUID `gorm:"type:uuid;uniqueIndex;not null"`
-					DefaultStore  bool      `gorm:"default:false;not null"`
-					Notifications bool      `gorm:"default:true;not null"`
-
-					CreatedAt time.Time
-					UpdatedAt time.Time
-					DeletedAt gorm.DeletedAt
-				}
-				return tx.AutoMigrate(&StoreUserPreference{})
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Migrator().DropTable("store_user_preferences")
-			},
-		},
-		{
-			// Create missing store_user_preferences records
-			ID: "202010071829_create_store_user_preferences_records",
-			Migrate: func(tx *gorm.DB) error {
-				var storeUsers []models.StoreUser
-				if err := tx.Where("active = ?", true).Find(&storeUsers).Error; err != nil {
-					return err
-				}
-				for i := range storeUsers {
-					storeUserPref := &models.StoreUserPreference{
-						ID:          uuid.NewV4(),
-						StoreUserID: storeUsers[i].ID,
-					}
-					if err := tx.Create(&storeUserPref).Error; err != nil {
-						return err
-					}
-				}
-				return nil
-			},
-			Rollback: func(tx *gorm.DB) error {
-				// Empty all records in the table
-				return tx.Exec("DELETE FROM store_user_preferences").Error
-			},
-		},
-		{
-			ID: "202011260730_add_device_name_to_auth_tokens",
-			Migrate: func(tx *gorm.DB) error {
-				type AuthToken struct {
-					DeviceName string `gorm:"type:varchar(100)"`
-				}
-				return tx.AutoMigrate(&AuthToken{})
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Exec("ALTER TABLE auth_tokens DROP COLUMN device_name").Error
-			},
-		},
-		{
-			// Create devices
-			ID: "202011291125_create_devices",
-			Migrate: func(tx *gorm.DB) error {
-				type Device struct {
-					ID     uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-					UserID uuid.UUID `gorm:"type:uuid;not null"`
-					Token  string    `gorm:"type:varchar(255);not null"`
-
-					CreatedAt time.Time
-					UpdatedAt time.Time
-					DeletedAt gorm.DeletedAt
-				}
-				return tx.AutoMigrate(&Device{})
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Migrator().DropTable("devices")
-			},
-		},
-		{
-			// Add meal_id to items
-			ID: "202012281946_add_meal_id_to_items",
-			Migrate: func(tx *gorm.DB) error {
-				type Item struct {
-					MealID *uuid.UUID `gorm:"type:uuid"`
-				}
-				return tx.AutoMigrate(&Item{})
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Migrator().DropColumn("items", "meal_id")
-			},
-		},
-		{
-			// Add indices for meals and meal_users columns
-			ID: "202101041619_meals_and_meal_users_indices",
-			Migrate: func(tx *gorm.DB) error {
-				if err := tx.Exec("CREATE INDEX idx_meals_created_at ON meals (created_at)").Error; err != nil {
-					return err
-				}
-				if err := tx.Exec("CREATE INDEX idx_meal_users_user_id ON meal_users (user_id)").Error; err != nil {
+				if err := tx.Exec("CREATE INDEX idx_meals_date ON meals (date)").Error; err != nil {
 					return err
 				}
 				return nil
 			},
 			Rollback: func(tx *gorm.DB) error {
-				if err := tx.Exec("DROP INDEX idx_meals_created_at").Error; err != nil {
-					return err
-				}
-				if err := tx.Exec("DROP INDEX idx_meal_users_user_id").Error; err != nil {
+				if err := tx.Exec("DROP INDEX idx_meals_date").Error; err != nil {
 					return err
 				}
 				return nil

--- a/internal/pkg/db/migration/main.go
+++ b/internal/pkg/db/migration/main.go
@@ -111,6 +111,16 @@ func AutoMigrateService(db *gorm.DB) error {
 				return nil
 			},
 		},
+		{
+			// Add index idx_auth_tokens_access_token
+			ID: "202101091252_add_idx_auth_tokens_access_token",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Exec("CREATE INDEX idx_auth_tokens_access_token ON auth_tokens (access_token)").Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec("DROP INDEX idx_auth_tokens_access_token").Error
+			},
+		},
 	})
 	return m.Migrate()
 }

--- a/internal/pkg/db/models/auth_token.go
+++ b/internal/pkg/db/models/auth_token.go
@@ -15,7 +15,7 @@ type AuthToken struct {
 	ID           uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
 	ClientID     uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();not null"`
 	UserID       uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();not null"`
-	AccessToken  string    `gorm:"type:varchar(100);not null"`
+	AccessToken  string    `gorm:"type:varchar(100);not null;index:idx_auth_tokens_access_token"`
 	RefreshToken string    `gorm:"type:varchar(100);not null"`
 	ExpiresIn    time.Time `gorm:"not null"`
 	DeviceName   string    `gorm:"type:varchar(100)"`

--- a/internal/pkg/db/models/grocery_trip.go
+++ b/internal/pkg/db/models/grocery_trip.go
@@ -10,7 +10,7 @@ import (
 
 type GroceryTrip struct {
 	ID                 uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-	StoreID            uuid.UUID `gorm:"type:uuid;not null"`
+	StoreID            uuid.UUID `gorm:"type:uuid;not null;index:idx_store_categories_store_id"`
 	Name               string    `gorm:"type:varchar(100);not null"`
 	Completed          bool      `gorm:"default:false;not null"`
 	CopyRemainingItems bool      `gorm:"default:false;not null"`

--- a/internal/pkg/db/models/grocery_trip_category.go
+++ b/internal/pkg/db/models/grocery_trip_category.go
@@ -9,8 +9,8 @@ import (
 
 type GroceryTripCategory struct {
 	ID              uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-	GroceryTripID   uuid.UUID `gorm:"type:uuid;not null"`
-	StoreCategoryID uuid.UUID `gorm:"type:uuid;not null"`
+	GroceryTripID   uuid.UUID `gorm:"type:uuid;not null;index:idx_grocery_trip_categories_grocery_trip_id"`
+	StoreCategoryID uuid.UUID `gorm:"type:uuid;not null;index:idx_grocery_trip_categories_store_category_id"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/pkg/db/models/meal.go
+++ b/internal/pkg/db/models/meal.go
@@ -17,7 +17,7 @@ type Meal struct {
 	MealType *string   `gorm:"type:varchar(10)"`
 	Servings int       `gorm:"default:1;not null"`
 	Notes    *string   `gorm:"type:text"`
-	Date     string    `gorm:"type:varchar(255);not null"`
+	Date     string    `gorm:"type:varchar(255);not null;index:idx_meals_date"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/pkg/db/models/meal_user.go
+++ b/internal/pkg/db/models/meal_user.go
@@ -11,7 +11,7 @@ import (
 type MealUser struct {
 	ID     uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
 	MealID uuid.UUID `gorm:"type:uuid;not null"`
-	UserID uuid.UUID `gorm:"type:uuid;not null"`
+	UserID uuid.UUID `gorm:"type:uuid;not null;index:idx_meal_users_user_id"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/pkg/db/models/store_category.go
+++ b/internal/pkg/db/models/store_category.go
@@ -9,7 +9,7 @@ import (
 
 type StoreCategory struct {
 	ID      uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-	StoreID uuid.UUID `gorm:"type:uuid;not null"`
+	StoreID uuid.UUID `gorm:"type:uuid;not null;index:idx_store_categories_store_id"`
 	Name    string    `gorm:"type:varchar(100);not null"`
 
 	CreatedAt time.Time

--- a/internal/pkg/db/models/store_user.go
+++ b/internal/pkg/db/models/store_user.go
@@ -11,7 +11,7 @@ import (
 
 type StoreUser struct {
 	ID      uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-	StoreID uuid.UUID `gorm:"type:uuid;not null"`
+	StoreID uuid.UUID `gorm:"type:uuid;not null;index:idx_store_users_store_id"`
 	UserID  uuid.UUID `gorm:"type:uuid"`
 	Email   string    `gorm:"type:varchar(100)"`
 	Creator *bool     `gorm:"default:false;not null"`


### PR DESCRIPTION
Some indices were added in migrations and not on the actual models themselves. The only remaining cases like this are where we have an index on multiple columns - I haven't figured out the proper way to do this in GORM. Once I found out though, I can remove those migrations too.