### PR TITLE
Add store_id column to meals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/denisenkom/go-mssqldb v0.0.0-20201104001602-427686ac8ec1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/go-gormigrate/gormigrate/v2 v2.0.0
-	github.com/gofrs/uuid v3.3.0+incompatible // indirect
+	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/graphql-go/graphql v0.7.9
 	github.com/graphql-go/handler v0.2.3

--- a/internal/pkg/db/migration/main.go
+++ b/internal/pkg/db/migration/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/gofrs/uuid"
 	"gorm.io/gorm"
 
 	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
@@ -112,13 +113,16 @@ func AutoMigrateService(db *gorm.DB) error {
 			},
 		},
 		{
-			// Add index idx_auth_tokens_access_token
-			ID: "202101091252_add_idx_auth_tokens_access_token",
+			// Add column store_id to meals
+			ID: "202101100852_add_store_id_to_meals",
 			Migrate: func(tx *gorm.DB) error {
-				return tx.Exec("CREATE INDEX idx_auth_tokens_access_token ON auth_tokens (access_token)").Error
+				type Meal struct {
+					StoreID uuid.UUID `gorm:"type:uuid;not null"`
+				}
+				return tx.AutoMigrate(&Meal{})
 			},
 			Rollback: func(tx *gorm.DB) error {
-				return tx.Exec("DROP INDEX idx_auth_tokens_access_token").Error
+				return tx.Exec("ALTER TABLE meals DROP COLUMN store_id").Error
 			},
 		},
 	})

--- a/internal/pkg/db/models/meal.go
+++ b/internal/pkg/db/models/meal.go
@@ -13,6 +13,7 @@ type Meal struct {
 	ID       uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
 	RecipeID uuid.UUID `gorm:"type:uuid;not null"`
 	UserID   uuid.UUID `gorm:"type:uuid;not null"`
+	StoreID  uuid.UUID `gorm:"type:uuid;not null"`
 	Name     string    `gorm:"type:varchar(255);not null;index:idx_meals_name"`
 	MealType *string   `gorm:"type:varchar(10)"`
 	Servings int       `gorm:"default:1;not null"`

--- a/internal/pkg/gql/types/meal.go
+++ b/internal/pkg/gql/types/meal.go
@@ -18,6 +18,9 @@ var MealType = graphql.NewObject(
 			"recipeId": &graphql.Field{
 				Type: graphql.NewNonNull(graphql.ID),
 			},
+			"storeId": &graphql.Field{
+				Type: graphql.NewNonNull(graphql.ID),
+			},
 			"name": &graphql.Field{
 				Type: graphql.NewNonNull(graphql.String),
 			},
@@ -46,6 +49,17 @@ var MealType = graphql.NewObject(
 						return nil, err
 					}
 					return users, nil
+				},
+			},
+			"store": &graphql.Field{
+				Type: StoreType,
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					var store models.Store
+					storeID := p.Source.(models.Meal).StoreID
+					if err := db.Manager.Where("id = ?", storeID).Last(&store).Error; err != nil {
+						return nil, err
+					}
+					return store, nil
 				},
 			},
 			"recipe": &graphql.Field{

--- a/internal/pkg/meals/plan_meal.go
+++ b/internal/pkg/meals/plan_meal.go
@@ -46,6 +46,7 @@ func PlanMeal(userID uuid.UUID, args map[string]interface{}) (meal *models.Meal,
 		meal = &models.Meal{
 			RecipeID: recipeID,
 			UserID:   userID,
+			StoreID:  storeID,
 			Name:     args["name"].(string),
 			MealType: &mealType,
 			Servings: args["servings"].(int),

--- a/internal/pkg/meals/plan_meal_test.go
+++ b/internal/pkg/meals/plan_meal_test.go
@@ -81,7 +81,7 @@ func (s *Suite) TestPlanMeal_Valid() {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "store_id", "user_id"}).AddRow(uuid.NewV4(), storeID, userID))
 
 	s.mock.ExpectQuery("^INSERT INTO \"meals\" (.+)$").
-		WithArgs(recipeID, userID, args["name"], args["mealType"], args["servings"], args["notes"], args["date"], AnyTime{}, AnyTime{}, nil).
+		WithArgs(recipeID, userID, storeID, args["name"], args["mealType"], args["servings"], args["notes"], args["date"], AnyTime{}, AnyTime{}, nil).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(mealID))
 
 	s.mock.ExpectQuery("^INSERT INTO \"meal_users\" (.+)$").


### PR DESCRIPTION
This way we can associate meals with stores. When a user views a meal, it needs to show which store they planned to shop at, and indicate that the meal is also shared with members of that store.