### PR TITLE
[Meal Planning] Allow recipe to be created with no ingredients

### DIFF
--- a/internal/pkg/gql/main.go
+++ b/internal/pkg/gql/main.go
@@ -439,7 +439,7 @@ func init() {
 							Type: graphql.String,
 						},
 						"ingredients": &graphql.ArgumentConfig{
-							Type: graphql.NewNonNull(graphql.NewList(graphql.NewInputObject(
+							Type: graphql.NewList(graphql.NewInputObject(
 								graphql.InputObjectConfig{
 									Name: "RecipeIngredientInput",
 									Fields: graphql.InputObjectConfigFieldMap{
@@ -457,7 +457,7 @@ func init() {
 										},
 									},
 								},
-							))),
+							)),
 						},
 					},
 					Resolve: resolvers.CreateRecipeResolver,

--- a/internal/pkg/meals/create_recipe.go
+++ b/internal/pkg/meals/create_recipe.go
@@ -20,12 +20,12 @@ func CreateRecipe(userID uuid.UUID, args map[string]interface{}) (recipe *models
 	}
 
 	ingredientsArg := args["ingredients"]
-	if ingredientsArg == nil {
-		return recipe, errors.New("cannot create a meal with no ingredients")
-	}
-	ingredients, err := CompileRecipeIngredients(ingredientsArg.([]interface{}))
-	if err != nil {
-		return recipe, errors.New("could not create ingredients")
+	var ingredients []models.RecipeIngredient
+	if ingredientsArg != nil {
+		ingredients, err = CompileRecipeIngredients(ingredientsArg.([]interface{}))
+		if err != nil {
+			return recipe, errors.New("could not create ingredients")
+		}
 	}
 	recipe = &models.Recipe{
 		UserID:      userID,
@@ -46,7 +46,6 @@ func CompileRecipeIngredients(ingArg []interface{}) (ingredients []models.Recipe
 		ing := ingArg[i].(map[string]interface{})
 
 		amount := ing["amount"].(float64)
-
 		unit := ing["unit"]
 		var unitStr string
 		if unit != nil {

--- a/internal/pkg/meals/create_recipe_test.go
+++ b/internal/pkg/meals/create_recipe_test.go
@@ -30,7 +30,6 @@ func (s *Suite) TestCreateRecipe_NoIngredients() {
 	assert.Equal(s.T(), recipe.MealType, &mealType)
 	url := args["url"].(string)
 	assert.Equal(s.T(), recipe.URL, &url)
-
 	assert.Equal(s.T(), len(recipe.Ingredients), 0)
 }
 


### PR DESCRIPTION
As I started testing meal planning I realized that sometimes you just want to link to a recipe without adding any ingredients. Or you just want to quickly add something you know how to make, and don't need to buy the ingredients for.  