### PR TITLE
Attribute meal name to items

### DIFF
--- a/data/FoodClassification.json
+++ b/data/FoodClassification.json
@@ -190,10 +190,6 @@
       "label": "Bakery"
     },
     {
-      "text": "flour tortillas",
-      "label": "Bakery"
-    },
-    {
       "text": "tortilla wraps",
       "label": "Bakery"
     },

--- a/internal/pkg/db/migration/main.go
+++ b/internal/pkg/db/migration/main.go
@@ -144,6 +144,19 @@ func AutoMigrateService(db *gorm.DB) error {
 				return tx.Exec("ALTER TABLE recipe_ingredients ALTER COLUMN amount SET DEFAULT 1").Error
 			},
 		},
+		{
+			// Add column meal_name to items
+			ID: "202102211048_add_meal_name_to_items",
+			Migrate: func(tx *gorm.DB) error {
+				type Item struct {
+					MealName *string `gorm:"type:varchar(255)"`
+				}
+				return tx.AutoMigrate(&Item{})
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec("ALTER TABLE items DROP COLUMN meal_name").Error
+			},
+		},
 	})
 	return m.Migrate()
 }

--- a/internal/pkg/db/models/item.go
+++ b/internal/pkg/db/models/item.go
@@ -13,12 +13,13 @@ type Item struct {
 	GroceryTripID uuid.UUID  `gorm:"type:uuid;not null;index:idx_items_grocery_trip_id_name"`
 	CategoryID    *uuid.UUID `gorm:"type:uuid;not null"`
 	UserID        uuid.UUID  `gorm:"type:uuid;not null"`
-	MealID        *uuid.UUID `gorm:"type:uuid"`
 	Name          string     `gorm:"type:varchar(100);not null;index:idx_items_grocery_trip_id_name"`
 	Quantity      int        `gorm:"default:1;not null"`
 	Completed     *bool      `gorm:"default:false;not null"`
 	Position      int        `gorm:"default:1;not null"`
 	Notes         *string    `gorm:"type:varchar(255)"`
+	MealID        *uuid.UUID `gorm:"type:uuid"`
+	MealName      *string    `gorm:"type:varchar(255)"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/pkg/gql/types/item.go
+++ b/internal/pkg/gql/types/item.go
@@ -62,12 +62,18 @@ var ItemType = graphql.NewObject(
 				Type: UserType,
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					userID := p.Source.(models.Item).UserID
-					user := &models.User{}
+					var user models.User
 					if err := db.Manager.Where("id = ?", userID).First(&user).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 						return nil, err
 					}
 					return user, nil
 				},
+			},
+			"mealId": &graphql.Field{
+				Type: graphql.ID,
+			},
+			"mealName": &graphql.Field{
+				Type: graphql.String,
 			},
 			"createdAt": &graphql.Field{
 				Type: graphql.DateTime,


### PR DESCRIPTION
Adds a new column `items.meal_name` and saves it when a meal is planned and its ingredients are added to a user's list.

Note that `items.meal_id` remains unused. I think we'd need it if/when we add a feature to allow the meal to be accessed from an item row, but not sure. It may be a candidate for removal.

Note: this PR inherits from #47.