### PR TITLE
Custom item category settings (fix)

### DIFF
--- a/internal/pkg/trips/update_item.go
+++ b/internal/pkg/trips/update_item.go
@@ -145,7 +145,7 @@ func UpdateStoreItemCategorySettings(
 // or makes a new map if one does not exist yet
 func CompileItemSettingsMap(itemSettings datatypes.JSON) (settings map[string]interface{}, err error) {
 	if itemSettings == nil {
-		settings = make(map[string]interface{})
+		return make(map[string]interface{}), nil
 	}
 	if err := json.Unmarshal(itemSettings, &settings); err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes a bug preventing creating a new `store_item_category_settings` record when an item's category is changed for the first time