### PR TITLE
Ensure store is correct when creating grocery trip category

### DIFF
--- a/internal/pkg/trips/add_item.go
+++ b/internal/pkg/trips/add_item.go
@@ -101,7 +101,14 @@ func FetchGroceryTripCategory(tripID uuid.UUID, name string) (category models.Gr
 // CreateGroceryTripCategory creates a grocery trip category by name
 func CreateGroceryTripCategory(tripID uuid.UUID, name string) (category models.GroceryTripCategory, err error) {
 	storeCategory := models.StoreCategory{}
-	query := db.Manager.Select("id").Where("name = ?", name).First(&storeCategory).Error
+	query := db.Manager.
+		Select("store_categories.id").
+		Joins("INNER JOIN stores ON stores.id = store_categories.store_id").
+		Joins("INNER JOIN grocery_trips ON grocery_trips.store_id = stores.id").
+		Where("store_categories.name = ?", name).
+		Where("grocery_trips.id = ?", tripID).
+		First(&storeCategory).
+		Error
 	if err := query; err != nil {
 		return category, errors.New("could not find store category")
 	}


### PR DESCRIPTION
This query needed to be scoped by store ID instead of creating a grocery trip category based off the first `store_categories` record with that name, regardless of store. This fixes a bug where setting an item category could create duplicate categories on the list, because that operation will always assign to a grocery trip category in that store.