### PR TITLE
Staple Items

### DIFF
--- a/internal/pkg/db/migration/main.go
+++ b/internal/pkg/db/migration/main.go
@@ -124,7 +124,6 @@ func AutoMigrateService(db *gorm.DB) error {
 				return tx.Migrator().DropTable("store_staple_items")
 			},
 		},
-
 		{
 			// Add index idx_store_staple_items_store_id_name
 			ID: "202105050820_add_idx_store_staple_items_store_id_name",
@@ -133,6 +132,19 @@ func AutoMigrateService(db *gorm.DB) error {
 			},
 			Rollback: func(tx *gorm.DB) error {
 				return tx.Exec("DROP INDEX idx_store_staple_items_store_id_name").Error
+			},
+		},
+		{
+			// Add column staple_id to items
+			ID: "202105060735_add_staple_id_to_items",
+			Migrate: func(tx *gorm.DB) error {
+				type Item struct {
+					StapleItemID *uuid.UUID `gorm:"type:uuid;index"`
+				}
+				return tx.AutoMigrate(&Item{})
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Migrator().DropColumn("people", "age")
 			},
 		},
 	})

--- a/internal/pkg/db/migration/main.go
+++ b/internal/pkg/db/migration/main.go
@@ -124,6 +124,17 @@ func AutoMigrateService(db *gorm.DB) error {
 				return tx.Migrator().DropTable("store_staple_items")
 			},
 		},
+
+		{
+			// Add index idx_store_staple_items_store_id_name
+			ID: "202105050820_add_idx_store_staple_items_store_id_name",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Exec("CREATE INDEX IF NOT EXISTS idx_store_staple_items_store_id_name ON store_staple_items (store_id, name)").Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec("DROP INDEX idx_store_staple_items_store_id_name").Error
+			},
+		},
 	})
 	return m.Migrate()
 }

--- a/internal/pkg/db/migration/main.go
+++ b/internal/pkg/db/migration/main.go
@@ -106,6 +106,24 @@ func AutoMigrateService(db *gorm.DB) error {
 				return tx.Migrator().DropTable("store_item_category_settings")
 			},
 		},
+		{
+			ID: "202105050742_create_store_staple_items",
+			Migrate: func(tx *gorm.DB) error {
+				type StoreStapleItem struct {
+					ID      uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+					StoreID uuid.UUID `gorm:"type:uuid;not null;index:idx_store_staple_items_store_id"`
+					Name    string    `gorm:"type:varchar(100);not null"`
+
+					CreatedAt time.Time
+					UpdatedAt time.Time
+					DeletedAt gorm.DeletedAt
+				}
+				return tx.AutoMigrate(&StoreStapleItem{})
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Migrator().DropTable("store_staple_items")
+			},
+		},
 	})
 	return m.Migrate()
 }

--- a/internal/pkg/db/models/item.go
+++ b/internal/pkg/db/models/item.go
@@ -13,6 +13,7 @@ type Item struct {
 	GroceryTripID uuid.UUID  `gorm:"type:uuid;not null;index:idx_items_grocery_trip_id_name"`
 	CategoryID    *uuid.UUID `gorm:"type:uuid;not null"`
 	UserID        uuid.UUID  `gorm:"type:uuid;not null"`
+	StapleItemID  *uuid.UUID `gorm:"type:uuid;index"`
 	Name          string     `gorm:"type:varchar(100);not null;index:idx_items_grocery_trip_id_name"`
 	Quantity      int        `gorm:"default:1;not null"`
 	Completed     *bool      `gorm:"default:false;not null"`
@@ -28,6 +29,7 @@ type Item struct {
 	// Associations
 	GroceryTrip GroceryTrip
 	Meal        Meal
+	StapleItem  StoreStapleItem
 }
 
 // BeforeCreate hook updates the item position

--- a/internal/pkg/db/models/store_staple_item.go
+++ b/internal/pkg/db/models/store_staple_item.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+type StoreStapleItem struct {
+	ID      uuid.UUID `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	StoreID uuid.UUID `gorm:"type:uuid;not null;index:idx_store_staple_items_store_id"`
+	Name    string    `gorm:"type:varchar(100);not null"`
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt
+
+	// Associations
+	Store Store
+}

--- a/internal/pkg/gql/main.go
+++ b/internal/pkg/gql/main.go
@@ -463,6 +463,19 @@ func init() {
 					},
 					Resolve: resolvers.AddItemsToStore,
 				},
+				"saveStapleItem": &graphql.Field{
+					Type:        gql.StoreStapleItemType,
+					Description: "Saves an item as a staple, meaning that will be automatically added to each trip",
+					Args: graphql.FieldConfigArgument{
+						"storeId": &graphql.ArgumentConfig{
+							Type: graphql.NewNonNull(graphql.ID),
+						},
+						"name": &graphql.ArgumentConfig{
+							Type: graphql.NewNonNull(graphql.String),
+						},
+					},
+					Resolve: resolvers.SaveStapleItem,
+				},
 				// Meals
 				"createRecipe": &graphql.Field{
 					Type:        gql.RecipeType,

--- a/internal/pkg/gql/main.go
+++ b/internal/pkg/gql/main.go
@@ -476,6 +476,16 @@ func init() {
 					},
 					Resolve: resolvers.SaveStapleItem,
 				},
+				"removeStapleItem": &graphql.Field{
+					Type:        gql.StoreStapleItemType,
+					Description: "Unmarks an item as a staple in a store",
+					Args: graphql.FieldConfigArgument{
+						"stapleItemId": &graphql.ArgumentConfig{
+							Type: graphql.NewNonNull(graphql.ID),
+						},
+					},
+					Resolve: resolvers.RemoveStapleItem,
+				},
 				// Meals
 				"createRecipe": &graphql.Field{
 					Type:        gql.RecipeType,

--- a/internal/pkg/gql/main.go
+++ b/internal/pkg/gql/main.go
@@ -470,8 +470,8 @@ func init() {
 						"storeId": &graphql.ArgumentConfig{
 							Type: graphql.NewNonNull(graphql.ID),
 						},
-						"name": &graphql.ArgumentConfig{
-							Type: graphql.NewNonNull(graphql.String),
+						"itemId": &graphql.ArgumentConfig{
+							Type: graphql.NewNonNull(graphql.ID),
 						},
 					},
 					Resolve: resolvers.SaveStapleItem,

--- a/internal/pkg/gql/main.go
+++ b/internal/pkg/gql/main.go
@@ -480,7 +480,7 @@ func init() {
 					Type:        gql.StoreStapleItemType,
 					Description: "Unmarks an item as a staple in a store",
 					Args: graphql.FieldConfigArgument{
-						"stapleItemId": &graphql.ArgumentConfig{
+						"itemId": &graphql.ArgumentConfig{
 							Type: graphql.NewNonNull(graphql.ID),
 						},
 					},

--- a/internal/pkg/gql/resolvers/remove_staple_item.go
+++ b/internal/pkg/gql/resolvers/remove_staple_item.go
@@ -15,11 +15,11 @@ func RemoveStapleItem(p graphql.ResolveParams) (interface{}, error) {
 		return nil, err
 	}
 
-	stapleItemID, err := uuid.FromString(p.Args["stapleItemId"].(string))
+	itemID, err := uuid.FromString(p.Args["itemId"].(string))
 	if err != nil {
 		return nil, err
 	}
-	item, err := stores.RemoveStapleItem(stapleItemID)
+	item, err := stores.RemoveStapleItem(itemID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/resolvers/remove_staple_item.go
+++ b/internal/pkg/gql/resolvers/remove_staple_item.go
@@ -1,0 +1,27 @@
+package resolvers
+
+import (
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
+	"github.com/graphql-go/graphql"
+	uuid "github.com/satori/go.uuid"
+)
+
+// RemoveStapleItem resolves the removeStapleItem mutation
+func RemoveStapleItem(p graphql.ResolveParams) (interface{}, error) {
+	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
+	_, err := auth.FetchAuthenticatedUser(header.(string))
+	if err != nil {
+		return nil, err
+	}
+
+	stapleItemID, err := uuid.FromString(p.Args["stapleItemId"].(string))
+	if err != nil {
+		return nil, err
+	}
+	item, err := stores.RemoveStapleItem(stapleItemID)
+	if err != nil {
+		return nil, err
+	}
+	return item, err
+}

--- a/internal/pkg/gql/resolvers/save_staple_item.go
+++ b/internal/pkg/gql/resolvers/save_staple_item.go
@@ -1,0 +1,28 @@
+package resolvers
+
+import (
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/stores"
+	"github.com/graphql-go/graphql"
+	uuid "github.com/satori/go.uuid"
+)
+
+// SaveStapleItem resolves the saveStapleItem mutation
+func SaveStapleItem(p graphql.ResolveParams) (interface{}, error) {
+	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
+	user, err := auth.FetchAuthenticatedUser(header.(string))
+	if err != nil {
+		return nil, err
+	}
+
+	storeID, err := uuid.FromString(p.Args["storeId"].(string))
+	if err != nil {
+		return nil, err
+	}
+	name := p.Args["name"].(string)
+	item, err := stores.SaveStapleItem(user.ID, storeID, name)
+	if err != nil {
+		return nil, err
+	}
+	return item, err
+}

--- a/internal/pkg/gql/resolvers/save_staple_item.go
+++ b/internal/pkg/gql/resolvers/save_staple_item.go
@@ -10,7 +10,7 @@ import (
 // SaveStapleItem resolves the saveStapleItem mutation
 func SaveStapleItem(p graphql.ResolveParams) (interface{}, error) {
 	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
-	user, err := auth.FetchAuthenticatedUser(header.(string))
+	_, err := auth.FetchAuthenticatedUser(header.(string))
 	if err != nil {
 		return nil, err
 	}
@@ -19,8 +19,11 @@ func SaveStapleItem(p graphql.ResolveParams) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	name := p.Args["name"].(string)
-	item, err := stores.SaveStapleItem(user.ID, storeID, name)
+	itemID, err := uuid.FromString(p.Args["itemId"].(string))
+	if err != nil {
+		return nil, err
+	}
+	item, err := stores.SaveStapleItem(storeID, itemID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/gql/types/item.go
+++ b/internal/pkg/gql/types/item.go
@@ -75,6 +75,9 @@ var ItemType = graphql.NewObject(
 			"mealName": &graphql.Field{
 				Type: graphql.String,
 			},
+			"stapleItemId": &graphql.Field{
+				Type: graphql.ID,
+			},
 			"createdAt": &graphql.Field{
 				Type: graphql.DateTime,
 			},

--- a/internal/pkg/gql/types/store_staple_item.go
+++ b/internal/pkg/gql/types/store_staple_item.go
@@ -1,0 +1,29 @@
+package gql
+
+import (
+	"github.com/graphql-go/graphql"
+)
+
+// StoreStapleItemType defines a graphql type for Item
+var StoreStapleItemType = graphql.NewObject(
+	graphql.ObjectConfig{
+		Name: "StoreStapleItem",
+		Fields: graphql.Fields{
+			"id": &graphql.Field{
+				Type: graphql.NewNonNull(graphql.ID),
+			},
+			"storeId": &graphql.Field{
+				Type: graphql.NewNonNull(graphql.ID),
+			},
+			"name": &graphql.Field{
+				Type: graphql.NewNonNull(graphql.String),
+			},
+			"createdAt": &graphql.Field{
+				Type: graphql.DateTime,
+			},
+			"updatedAt": &graphql.Field{
+				Type: graphql.DateTime,
+			},
+		},
+	},
+)

--- a/internal/pkg/meals/plan_meal_test.go
+++ b/internal/pkg/meals/plan_meal_test.go
@@ -118,7 +118,7 @@ func (s *Suite) TestPlanMeal_Valid() {
 	s.mock.ExpectExec("^UPDATE items SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	s.mock.ExpectQuery("^INSERT INTO \"items\" (.+)$").
-		WithArgs(tripID, sqlmock.AnyArg(), userID, itemName, quantity, false, 1, nil, nil, nil, AnyTime{}, AnyTime{}, nil).
+		WithArgs(tripID, sqlmock.AnyArg(), userID, nil, itemName, quantity, false, 1, nil, nil, nil, AnyTime{}, AnyTime{}, nil).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(itemID))
 	s.mock.ExpectExec("^UPDATE \"grocery_trips\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))

--- a/internal/pkg/stores/remove_staple_item.go
+++ b/internal/pkg/stores/remove_staple_item.go
@@ -1,0 +1,20 @@
+package stores
+
+import (
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
+	uuid "github.com/satori/go.uuid"
+)
+
+// RemoveStapleItem saves an item as a staple in the store ID provided
+func RemoveStapleItem(stapleItemID uuid.UUID) (staple models.StoreStapleItem, err error) {
+	if err := db.Manager.Where("id = ?", stapleItemID).First(&staple).Error; err != nil {
+		return staple, err
+	}
+
+	// This makes for quick lookup and setting/unsetting items as staples
+	if err := db.Manager.Delete(&staple).Error; err != nil {
+		return staple, err
+	}
+	return staple, nil
+}

--- a/internal/pkg/stores/remove_staple_item.go
+++ b/internal/pkg/stores/remove_staple_item.go
@@ -7,14 +7,20 @@ import (
 )
 
 // RemoveStapleItem saves an item as a staple in the store ID provided
-func RemoveStapleItem(stapleItemID uuid.UUID) (staple models.StoreStapleItem, err error) {
-	if err := db.Manager.Where("id = ?", stapleItemID).First(&staple).Error; err != nil {
+func RemoveStapleItem(itemID uuid.UUID) (staple models.StoreStapleItem, err error) {
+	var item models.Item
+	if err := db.Manager.Select("staple_item_id").Where("id = ?", itemID).First(&item).Error; err != nil {
 		return staple, err
 	}
 
-	// This makes for quick lookup and setting/unsetting items as staples
-	if err := db.Manager.Delete(&staple).Error; err != nil {
+	if err := db.Manager.Where("id = ?", item.StapleItemID).Delete(&staple).Error; err != nil {
 		return staple, err
 	}
+
+	// Update the item to dissociate staple_item_id
+	if err := db.Manager.Model(&item).Where("staple_item_id = ?", item.StapleItemID).Update("staple_item_id", nil).Error; err != nil {
+		return staple, err
+	}
+
 	return staple, nil
 }

--- a/internal/pkg/stores/remove_staple_item.go
+++ b/internal/pkg/stores/remove_staple_item.go
@@ -6,19 +6,22 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-// RemoveStapleItem saves an item as a staple in the store ID provided
+// RemoveStapleItem dissocates any staple_item_id from items for this staple item and deletes the staple item
 func RemoveStapleItem(itemID uuid.UUID) (staple models.StoreStapleItem, err error) {
 	var item models.Item
 	if err := db.Manager.Select("staple_item_id").Where("id = ?", itemID).First(&item).Error; err != nil {
 		return staple, err
 	}
-
 	if err := db.Manager.Where("id = ?", item.StapleItemID).Delete(&staple).Error; err != nil {
 		return staple, err
 	}
 
-	// Update the item to dissociate staple_item_id
-	if err := db.Manager.Model(&item).Where("staple_item_id = ?", item.StapleItemID).Update("staple_item_id", nil).Error; err != nil {
+	updateQuery := db.Manager.
+		Model(&item).
+		Where("staple_item_id = ?", item.StapleItemID).
+		Update("staple_item_id", nil).
+		Error
+	if err := updateQuery; err != nil {
 		return staple, err
 	}
 

--- a/internal/pkg/stores/remove_staple_item_test.go
+++ b/internal/pkg/stores/remove_staple_item_test.go
@@ -1,0 +1,33 @@
+package stores
+
+import (
+	"github.com/DATA-DOG/go-sqlmock"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func (s *Suite) TestRemoveStapleItem_StapleItemNotFound() {
+	itemID := uuid.NewV4()
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_staple_items\"*").
+		WithArgs(itemID).
+		WillReturnRows(sqlmock.NewRows([]string{}))
+
+	_, err := RemoveStapleItem(itemID)
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), err.Error(), "record not found")
+}
+
+func (s *Suite) TestRemoveStapleItem_StapleItemRemoved() {
+	itemID := uuid.NewV4()
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_staple_items\"*").
+		WithArgs(itemID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(itemID))
+
+	s.mock.ExpectExec("^UPDATE \"store_staple_items\"*").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	stapleItem, err := RemoveStapleItem(itemID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), stapleItem.ID, itemID)
+}

--- a/internal/pkg/stores/remove_staple_item_test.go
+++ b/internal/pkg/stores/remove_staple_item_test.go
@@ -9,7 +9,7 @@ import (
 
 func (s *Suite) TestRemoveStapleItem_StapleItemNotFound() {
 	itemID := uuid.NewV4()
-	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_staple_items\"*").
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
 		WithArgs(itemID).
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
@@ -20,14 +20,20 @@ func (s *Suite) TestRemoveStapleItem_StapleItemNotFound() {
 
 func (s *Suite) TestRemoveStapleItem_StapleItemRemoved() {
 	itemID := uuid.NewV4()
-	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_staple_items\"*").
+	stapleItemID := uuid.NewV4()
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
 		WithArgs(itemID).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(itemID))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "staple_item_id"}).AddRow(itemID, stapleItemID))
 
 	s.mock.ExpectExec("^UPDATE \"store_staple_items\"*").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	stapleItem, err := RemoveStapleItem(itemID)
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+		WithArgs(itemID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(itemID))
+	s.mock.ExpectExec("^UPDATE \"items\"*").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	_, err := RemoveStapleItem(itemID)
 	require.NoError(s.T(), err)
-	assert.Equal(s.T(), stapleItem.ID, itemID)
 }

--- a/internal/pkg/stores/save_staple_item.go
+++ b/internal/pkg/stores/save_staple_item.go
@@ -1,0 +1,27 @@
+package stores
+
+import (
+	"errors"
+
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
+	uuid "github.com/satori/go.uuid"
+	"gorm.io/gorm"
+)
+
+// SaveStapleItem saves an item as a staple in the store ID provided
+func SaveStapleItem(userID uuid.UUID, storeID uuid.UUID, name string) (staple models.StoreStapleItem, err error) {
+	userExistsQuery := db.Manager.
+		First(&models.StoreUser{}).
+		Where("user_id = ? AND store_id = ?", userID, storeID).
+		Error
+	if errors.Is(userExistsQuery, gorm.ErrRecordNotFound) {
+		return staple, errors.New("user does not belong to this store")
+	}
+
+	stapleItem := models.StoreStapleItem{StoreID: storeID, Name: name}
+	if err := db.Manager.Where(stapleItem).FirstOrCreate(&stapleItem).Error; err != nil {
+		return staple, err
+	}
+	return stapleItem, nil
+}

--- a/internal/pkg/stores/save_staple_item.go
+++ b/internal/pkg/stores/save_staple_item.go
@@ -9,7 +9,6 @@ import (
 )
 
 // SaveStapleItem saves an item as a staple in the store ID provided
-// TODO test this
 func SaveStapleItem(storeID uuid.UUID, itemID uuid.UUID) (staple models.StoreStapleItem, err error) {
 	var item models.Item
 	if err := db.Manager.Where("id = ?", itemID).First(&item).Error; err != nil {

--- a/internal/pkg/stores/save_staple_item_test.go
+++ b/internal/pkg/stores/save_staple_item_test.go
@@ -1,0 +1,70 @@
+package stores
+
+import (
+	"github.com/DATA-DOG/go-sqlmock"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func (s *Suite) TestSaveStapleItem_ItemNotFound() {
+	itemID := uuid.NewV4()
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+		WithArgs(itemID).
+		WillReturnRows(sqlmock.NewRows([]string{}))
+
+	storeID := uuid.NewV4()
+	_, err := SaveStapleItem(storeID, itemID)
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), err.Error(), "record not found")
+}
+
+func (s *Suite) TestSaveStapleItem_FindExistingStapleItem() {
+	itemID := uuid.NewV4()
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+		WithArgs(itemID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(itemID))
+
+	stapleItemID := uuid.NewV4()
+	storeID := uuid.NewV4()
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_staple_items\"*").
+		WithArgs(storeID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "store_id"}).AddRow(stapleItemID, storeID))
+
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+		WithArgs(itemID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(itemID))
+	s.mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	stapleItem, err := SaveStapleItem(storeID, itemID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), stapleItem.ID, stapleItemID)
+}
+
+func (s *Suite) TestSaveStapleItem_CreateNewStapleItem() {
+	itemID := uuid.NewV4()
+	itemName := "Apples"
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+		WithArgs(itemID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(itemID, itemName))
+
+	stapleItemID := uuid.NewV4()
+	storeID := uuid.NewV4()
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_staple_items\"*").
+		WithArgs(storeID, itemName).
+		WillReturnRows(sqlmock.NewRows([]string{}))
+	s.mock.ExpectQuery("^INSERT INTO \"store_staple_items\" (.+)$").
+		WithArgs(storeID, itemName, AnyTime{}, AnyTime{}, nil).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(stapleItemID))
+
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"items\"*").
+		WithArgs(itemID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(itemID))
+	s.mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	stapleItem, err := SaveStapleItem(storeID, itemID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), stapleItem.ID, stapleItemID)
+}

--- a/internal/pkg/trips/add_item.go
+++ b/internal/pkg/trips/add_item.go
@@ -51,6 +51,11 @@ func AddItem(userID uuid.UUID, args map[string]interface{}) (addedItem *models.I
 		Completed:     &itemCompleted,
 	}
 
+	if args["stapleItemId"] != nil {
+		stapleItemID := args["stapleItemId"].(uuid.UUID)
+		item.StapleItemID = &stapleItemID
+	}
+
 	// If categoryName is explicitly provided in the arguments, use it,
 	// otherwise we need to determine it automagically ✨
 	var categoryName string

--- a/internal/pkg/trips/add_item_test.go
+++ b/internal/pkg/trips/add_item_test.go
@@ -57,7 +57,7 @@ func (s *Suite) TestAddItem_AddsItemToTripWithCategoryName() {
 
 	itemID := uuid.NewV4()
 	s.mock.ExpectQuery("^INSERT INTO \"items\" (.+)$").
-		WithArgs(trip.ID, sqlmock.AnyArg(), userID, "Apples", 5, false, 1, nil, nil, nil, AnyTime{}, AnyTime{}, nil).
+		WithArgs(trip.ID, sqlmock.AnyArg(), userID, nil, "Apples", 5, false, 1, nil, nil, nil, AnyTime{}, AnyTime{}, nil).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(itemID))
 
 	item, err := AddItem(userID, args)
@@ -86,7 +86,7 @@ func (s *Suite) TestAddItem_NoQuantityArg() {
 
 	itemID := uuid.NewV4()
 	s.mock.ExpectQuery("^INSERT INTO \"items\" (.+)$").
-		WithArgs(trip.ID, sqlmock.AnyArg(), userID, "Kleenex", 1, false, 1, nil, nil, nil, AnyTime{}, AnyTime{}, nil).
+		WithArgs(trip.ID, sqlmock.AnyArg(), userID, nil, "Kleenex", 1, false, 1, nil, nil, nil, AnyTime{}, AnyTime{}, nil).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(itemID))
 
 	item, err := AddItem(userID, args)
@@ -116,7 +116,7 @@ func (s *Suite) TestAddItem_InlineQuantityInItemName() {
 
 	itemID := uuid.NewV4()
 	s.mock.ExpectQuery("^INSERT INTO \"items\" (.+)$").
-		WithArgs(trip.ID, sqlmock.AnyArg(), userID, "Apples", 6, false, 1, nil, nil, nil, AnyTime{}, AnyTime{}, nil).
+		WithArgs(trip.ID, sqlmock.AnyArg(), userID, nil, "Apples", 6, false, 1, nil, nil, nil, AnyTime{}, AnyTime{}, nil).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(itemID))
 
 	item, err := AddItem(userID, args)

--- a/internal/pkg/trips/update_trip.go
+++ b/internal/pkg/trips/update_trip.go
@@ -32,16 +32,6 @@ func UpdateTrip(args map[string]interface{}) (interface{}, error) {
 	// If the trip was completed, create the next trip for the user
 	if trip.Completed {
 		db.Manager.Transaction(func(tx *gorm.DB) error {
-			var tripsCount int64
-			tripsCountQuery := tx.
-				Model(&models.GroceryTrip{}).
-				Where("store_id = ?", trip.StoreID).
-				Count(&tripsCount).
-				Error
-			if err := tripsCountQuery; err != nil {
-				return err
-			}
-
 			var newTripName string
 			// If a newTripName argument is passed, use it instead of creating one from the
 			// current date in server time; typically this argument will be passed from
@@ -58,69 +48,89 @@ func UpdateTrip(args map[string]interface{}) (interface{}, error) {
 			}
 
 			if trip.CopyRemainingItems {
-				// Duplicate the category associated with each item
-				var remainingItems []models.Item
-				if err := tx.Where("grocery_trip_id = ? AND completed = ?", trip.ID, false).Find(&remainingItems).Error; err != nil {
-					return err
-				}
-
-				var newItems []models.Item
-				for i := range remainingItems {
-					// Retrieve the store category associated with the previous trip and use it
-					// to create a duplicate grocery trip category in new trip
-					// (note: use FindOrCreate to avoid dupe categories)
-					storeCategory := &models.StoreCategory{}
-					storeCategoryQuery := tx.
-						Select("store_categories.id, store_categories.name").
-						Joins("INNER JOIN grocery_trip_categories ON grocery_trip_categories.store_category_id = store_categories.id").
-						Where("grocery_trip_categories.id = ?", remainingItems[i].CategoryID).
-						Find(&storeCategory).
-						Error
-					if err := storeCategoryQuery; err != nil {
-						return err
-					}
-					// Note: uses FirstOrCreate to handle the case where there are multiple items in same category
-					// that need to be moved over to the next trip
-					groceryTripCategory := models.GroceryTripCategory{
-						GroceryTripID:   newTrip.ID,
-						StoreCategoryID: storeCategory.ID,
-					}
-					if err := tx.Where(groceryTripCategory).FirstOrCreate(&groceryTripCategory).Error; err != nil {
-						return err
-					}
-
-					// Copy old item to new item and update values
-					newItem := remainingItems[i]
-					newItem.ID = uuid.Nil
-					newItem.GroceryTripID = newTrip.ID
-					newItem.CategoryID = &groceryTripCategory.ID
-					newItem.CreatedAt = time.Now()
-					newItem.UpdatedAt = time.Now()
-					newItems = append(newItems, newItem)
-				}
-
-				// Batch insert items in new trip
-				if err := tx.Create(&newItems).Error; err != nil {
+				if err := CopyRemainingItemsToNewTrip(trip, newTrip, tx); err != nil {
 					return err
 				}
 			}
 
-			// Mark each item in the old trip as completed
-			//
-			// This uses UpdateColumn to avoid hooks
-			// (https://gorm.io/docs/update.html#Without-Hooks-Time-Tracking)
-			updateItemsQuery := tx.
-				Model(&models.Item{}).
-				Where("grocery_trip_id = ? AND completed = ?", trip.ID, false).
-				UpdateColumn("completed", true).
-				Error
-			if err := updateItemsQuery; err != nil {
+			if err := MarkItemsInOldTripAsCompleted(trip, tx); err != nil {
 				return err
 			}
+
+			// TODO: Move staple items to new trip
 
 			return nil
 		})
 	}
 
 	return trip, nil
+}
+
+func CopyRemainingItemsToNewTrip(
+	trip models.GroceryTrip,
+	newTrip *models.GroceryTrip,
+	tx *gorm.DB,
+) (err error) {
+	// Duplicate the category associated with each item
+	var remainingItems []models.Item
+	if err := tx.Where("grocery_trip_id = ? AND completed = ?", trip.ID, false).Find(&remainingItems).Error; err != nil {
+		return err
+	}
+
+	var newItems []models.Item
+	for i := range remainingItems {
+		// Retrieve the store category associated with the previous trip and use it
+		// to create a duplicate grocery trip category in new trip
+		// (note: use FindOrCreate to avoid dupe categories)
+		storeCategory := &models.StoreCategory{}
+		storeCategoryQuery := tx.
+			Select("store_categories.id, store_categories.name").
+			Joins("INNER JOIN grocery_trip_categories ON grocery_trip_categories.store_category_id = store_categories.id").
+			Where("grocery_trip_categories.id = ?", remainingItems[i].CategoryID).
+			Find(&storeCategory).
+			Error
+		if err := storeCategoryQuery; err != nil {
+			return err
+		}
+		// Note: uses FirstOrCreate to handle the case where there are multiple items in same category
+		// that need to be moved over to the next trip
+		groceryTripCategory := models.GroceryTripCategory{
+			GroceryTripID:   newTrip.ID,
+			StoreCategoryID: storeCategory.ID,
+		}
+		if err := tx.Where(groceryTripCategory).FirstOrCreate(&groceryTripCategory).Error; err != nil {
+			return err
+		}
+
+		// Copy old item to new item and update values
+		newItem := remainingItems[i]
+		newItem.ID = uuid.Nil
+		newItem.GroceryTripID = newTrip.ID
+		newItem.CategoryID = &groceryTripCategory.ID
+		newItem.CreatedAt = time.Now()
+		newItem.UpdatedAt = time.Now()
+		newItems = append(newItems, newItem)
+	}
+
+	// Batch insert items in new trip
+	if err := tx.Create(&newItems).Error; err != nil {
+		return err
+	}
+	return
+}
+
+// MarkItemsInOldTripAsCompleted marks each item in the old trip as completed
+//
+// This uses UpdateColumn to avoid hooks
+// (https://gorm.io/docs/update.html#Without-Hooks-Time-Tracking)
+func MarkItemsInOldTripAsCompleted(trip models.GroceryTrip, tx *gorm.DB) (err error) {
+	updateItemsQuery := tx.
+		Model(&models.Item{}).
+		Where("grocery_trip_id = ? AND completed = ?", trip.ID, false).
+		UpdateColumn("completed", true).
+		Error
+	if err := updateItemsQuery; err != nil {
+		return err
+	}
+	return
 }

--- a/internal/pkg/trips/update_trip.go
+++ b/internal/pkg/trips/update_trip.go
@@ -147,7 +147,7 @@ func MarkItemsInOldTripAsCompleted(trip models.GroceryTrip, tx *gorm.DB) (err er
 // AddStapleItemsToNewTrip adds items set as staple items for this store to the new trip
 func AddStapleItemsToNewTrip(trip models.GroceryTrip) (err error) {
 	var store models.Store
-	if err := db.Manager.Where("id = ?", trip.StoreID).First(&store).Error; err != nil {
+	if err := db.Manager.Select("id, user_id").Where("id = ?", trip.StoreID).First(&store).Error; err != nil {
 		return err
 	}
 

--- a/internal/pkg/trips/update_trip.go
+++ b/internal/pkg/trips/update_trip.go
@@ -157,10 +157,11 @@ func AddStapleItemsToNewTrip(trip models.GroceryTrip) (err error) {
 	}
 
 	for i := range stapleItems {
+		stapleItem := stapleItems[i]
 		args := map[string]interface{}{
 			"tripId":       trip.ID,
-			"name":         stapleItems[i].Name,
-			"stapleItemId": stapleItems[i].ID,
+			"name":         stapleItem.Name,
+			"stapleItemId": stapleItem.ID,
 		}
 		userID := store.UserID
 		_, err := AddItem(userID, args)

--- a/internal/pkg/trips/update_trip_test.go
+++ b/internal/pkg/trips/update_trip_test.go
@@ -60,10 +60,6 @@ func (s *Suite) TestUpdateTrip_DupeTripName() {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	s.mock.ExpectBegin()
-	s.mock.ExpectQuery("^SELECT count*").
-		WithArgs(storeID).
-		WillReturnRows(s.mock.NewRows([]string{"count"}).AddRow(0))
-
 	// Test case where a trip already exists in this store with this name
 	// and assert that it affixes a count after the name
 	//
@@ -82,6 +78,14 @@ func (s *Suite) TestUpdateTrip_DupeTripName() {
 	s.mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	s.mock.ExpectCommit()
+
+	// AddStapleItemsToNewTrip
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+		WithArgs(storeID).
+		WillReturnRows(s.mock.NewRows([]string{"id"}).AddRow(storeID))
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_staple_items\"*").
+		WithArgs(storeID).
+		WillReturnRows(s.mock.NewRows([]string{}))
 
 	trip, err := UpdateTrip(args)
 	require.NoError(s.T(), err)
@@ -107,10 +111,6 @@ func (s *Suite) TestUpdateTrip_MarkCompleted() {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	s.mock.ExpectBegin()
-	s.mock.ExpectQuery("^SELECT count*").
-		WithArgs(storeID).
-		WillReturnRows(s.mock.NewRows([]string{"count"}).AddRow(1))
-
 	currentTime := time.Now()
 	tripName := currentTime.Format("Jan 2, 2006")
 	likeTripName := fmt.Sprintf("%%%s%%", tripName)
@@ -124,6 +124,14 @@ func (s *Suite) TestUpdateTrip_MarkCompleted() {
 	s.mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	s.mock.ExpectCommit()
+
+	// AddStapleItemsToNewTrip
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+		WithArgs(storeID).
+		WillReturnRows(s.mock.NewRows([]string{"id"}).AddRow(storeID))
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_staple_items\"*").
+		WithArgs(storeID).
+		WillReturnRows(s.mock.NewRows([]string{}))
 
 	trip, err := UpdateTrip(args)
 	require.NoError(s.T(), err)
@@ -142,10 +150,6 @@ func (s *Suite) TestUpdateTrip_MarkCompletedAndCopyRemainingItems() {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	s.mock.ExpectBegin()
-	s.mock.ExpectQuery("^SELECT count*").
-		WithArgs(storeID).
-		WillReturnRows(s.mock.NewRows([]string{"count"}).AddRow(1))
-
 	newTripID := uuid.NewV4()
 	currentTime := time.Now()
 	tripName := currentTime.Format("Jan 2, 2006")
@@ -171,7 +175,7 @@ func (s *Suite) TestUpdateTrip_MarkCompletedAndCopyRemainingItems() {
 		WithArgs(newTripID, storeCategoryID).
 		WillReturnRows(s.mock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
 	s.mock.ExpectQuery("^INSERT INTO \"items\" (.+)$").
-		WithArgs(newTripID, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), 1, false, 1, nil, sqlmock.AnyArg(), sqlmock.AnyArg(), AnyTime{}, AnyTime{}, nil).
+		WithArgs(newTripID, sqlmock.AnyArg(), sqlmock.AnyArg(), nil, sqlmock.AnyArg(), 1, false, 1, nil, sqlmock.AnyArg(), sqlmock.AnyArg(), AnyTime{}, AnyTime{}, nil).
 		WillReturnRows(s.mock.NewRows([]string{"id"}).AddRow(uuid.NewV4()))
 	s.mock.ExpectExec("^UPDATE \"items\" SET (.+)$").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -182,6 +186,14 @@ func (s *Suite) TestUpdateTrip_MarkCompletedAndCopyRemainingItems() {
 		"copyRemainingItems": true,
 	}
 	s.mock.ExpectCommit()
+
+	// AddStapleItemsToNewTrip
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"stores\"*").
+		WithArgs(storeID).
+		WillReturnRows(s.mock.NewRows([]string{"id"}).AddRow(storeID))
+	s.mock.ExpectQuery("^SELECT (.+) FROM \"store_staple_items\"*").
+		WithArgs(storeID).
+		WillReturnRows(s.mock.NewRows([]string{}))
 
 	trip, err := UpdateTrip(args)
 	require.NoError(s.T(), err)


### PR DESCRIPTION
This allows users to mark items as staples. Staple items will automatically be placed in a list for each new trip.

## TODO

- [x] Migration and models
- [x] Add staple items to new trips automatically
- [x] Tests
- [x] Ability to remove staple item
- [x] ~Support quantity (save staple item as e.g. "Apples x 4" should work)~  (won't do)
