### PR TITLE
Ability to delete account

### DIFF
--- a/internal/pkg/gql/main.go
+++ b/internal/pkg/gql/main.go
@@ -240,6 +240,11 @@ func init() {
 					},
 					Resolve: resolvers.ResetPasswordResolver,
 				},
+				"deleteAccount": &graphql.Field{
+					Type:        gql.UserType,
+					Description: "Deletes a user account",
+					Resolve:     resolvers.DeleteAccountResolver,
+				},
 				"createStore": &graphql.Field{
 					Type:        gql.StoreType,
 					Description: "Create a store",

--- a/internal/pkg/gql/resolvers/delete_account.go
+++ b/internal/pkg/gql/resolvers/delete_account.go
@@ -1,0 +1,22 @@
+package resolvers
+
+import (
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/auth"
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/user"
+	"github.com/graphql-go/graphql"
+)
+
+// DeleteAccountResolver resolves the deleteAccount mutation
+func DeleteAccountResolver(p graphql.ResolveParams) (interface{}, error) {
+	header := p.Info.RootValue.(map[string]interface{})["Authorization"]
+	authUser, err := auth.FetchAuthenticatedUser(header.(string))
+	if err != nil {
+		return nil, err
+	}
+
+	deletedUser, err := user.DeleteAccount(authUser)
+	if err != nil {
+		return nil, err
+	}
+	return deletedUser, nil
+}

--- a/internal/pkg/user/delete_account.go
+++ b/internal/pkg/user/delete_account.go
@@ -1,0 +1,17 @@
+package user
+
+import (
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db"
+	"github.com/bradpurchase/grocerytime-backend/internal/pkg/db/models"
+)
+
+// DeleteAccount deletes a user account
+//
+// This is a permanent delete, not a soft delete.
+// The User model has a BeforeDelete hook to remove/clean associated data
+func DeleteAccount(user models.User) (deletedUser models.User, err error) {
+	if err := db.Manager.Unscoped().Delete(&user).Error; err != nil {
+		return deletedUser, err
+	}
+	return user, err
+}


### PR DESCRIPTION
Adds the ability to close a user account, which does hard-deleting on the user record and all associations. This is done to adhere to the new App Store Guidelines rule:

> 5.1.1(v): Apps supporting account creation must also offer account deletion.